### PR TITLE
Ability to make anonymous requests

### DIFF
--- a/lib/wise_homex/config.ex
+++ b/lib/wise_homex/config.ex
@@ -20,7 +20,7 @@ defmodule WiseHomex.Config do
   @doc """
   Helper for making an anonymous config.
 
-  iex> new_anonymous_config()
+  iex> anonymous_config()
   %WiseHomex.Config{
               api_version: "v6",
               authorization_header: nil,

--- a/lib/wise_homex/config.ex
+++ b/lib/wise_homex/config.ex
@@ -18,6 +18,21 @@ defmodule WiseHomex.Config do
             base_url: "https://api.wisehome.dk"
 
   @doc """
+  Helper for making an anonymous config.
+
+  iex> new_anonymous_config()
+  %WiseHomex.Config{
+              api_version: "v6",
+              authorization_header: nil,
+              base_url: "https://api.wisehome.dk",
+              timeout: 5000
+            }
+  """
+  def anonymous_config(opts \\ []) do
+    new_config(:auth_header, nil, opts)
+  end
+
+  @doc """
   Return a WiseHomex.Config from an authentication method.
 
   :plain uses authentication with email and password
@@ -69,7 +84,7 @@ defmodule WiseHomex.Config do
     new_config(:auth_header, auth_header, opts)
   end
 
-  def new_config(:auth_header, auth_header, opts) when is_binary(auth_header) do
+  def new_config(:auth_header, auth_header, opts) when is_binary(auth_header) or is_nil(auth_header) do
     default_configuration = %__MODULE__{authorization_header: auth_header}
 
     opts

--- a/lib/wise_homex/request.ex
+++ b/lib/wise_homex/request.ex
@@ -72,11 +72,12 @@ defmodule WiseHomex.Request do
 
   # Build HTTP request headers from an ApiClient.Config
   defp build_headers(%Config{authorization_header: authorization_header}) do
-    %{
-      "authorization" => authorization_header,
-      "content-type" => "application/vnd.api+json"
-    }
+    %{"content-type" => "application/vnd.api+json"}
+    |> add_authorization_header(authorization_header)
   end
+
+  defp add_authorization_header(headers, nil), do: headers
+  defp add_authorization_header(headers, auth_header), do: headers |> Map.put(:authorization, auth_header)
 
   # Build options for HTTPoison from an ApiClient.Config
   defp build_options(%Config{timeout: timeout}) do

--- a/lib/wise_homex/request.ex
+++ b/lib/wise_homex/request.ex
@@ -76,6 +76,7 @@ defmodule WiseHomex.Request do
     |> add_authorization_header(authorization_header)
   end
 
+  # Conditionally add the authorization header to a map of headers
   defp add_authorization_header(headers, nil), do: headers
   defp add_authorization_header(headers, auth_header), do: headers |> Map.put(:authorization, auth_header)
 


### PR DESCRIPTION
Fixes #6 by conditionally adding the `authorization` header. If `authorization_header` in the `%Config{}` struct is nil, the client doesn't add the header to the request.

Note that the functionality is not tested, because this is waiting for https://github.com/wise-home/wise_homex/issues/3