### PR TITLE
Include company number as required attr in unic sync

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -428,8 +428,8 @@ defmodule WiseHomex do
   @doc """
   Create a synced property from unik
   """
-  def create_synced_property_unik(config, unik_property_number, admin_id),
-    do: api_client().create_synced_property_unik(config, unik_property_number, admin_id)
+  def create_synced_property_unik(config, property_number, company_number, admin_id),
+    do: api_client().create_synced_property_unik(config, property_number, company_number, admin_id)
 
   # Reports
 

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -9,7 +9,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @type response :: WiseHomex.ResponseParser.response() | :econnrefused | :connect_timeout | :closed
 
   @type id :: String.t()
-  @type unik_number :: String.t()
+  @type unik_number :: pos_integer
   @type query :: map
   @type attributes :: map
   @type relationships :: map
@@ -106,7 +106,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback sync_property(Config.t(), id) :: response
 
   # Property Syncs UNIK
-  @callback create_synced_property_unik(Config.t(), unik_number, id) :: response
+  @callback create_synced_property_unik(Config.t(), unik_number, unik_number, id) :: response
 
   # Reports
   @callback create_latest_report(Config.t(), id, query) :: response

--- a/lib/wise_homex/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl.ex
@@ -548,15 +548,17 @@ defmodule WiseHomex.ApiClientImpl do
   # Property Syncs UNIK
 
   @doc """
-  Create a synced property from an external system
+  Create a synced property from UNIK
+  Both property_number and company_number are the numbers from the UNIK system
   """
-  def create_synced_property_unik(config, unik_property_number, admin_id) do
+  def create_synced_property_unik(config, property_number, company_number, admin_id) do
     params =
       %{
         data: %{
           type: "property-syncs",
           attributes: %{
-            number: unik_property_number
+            property_number: property_number,
+            company_number: company_number
           },
           relationships: %{
             admin: %{data: %{type: "accounts", id: admin_id}}

--- a/lib/wise_homex/test/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock.ex
@@ -255,9 +255,10 @@ defmodule WiseHomex.Test.ApiClientMock do
   end
 
   # Property Syncs UNIK
-  def create_synced_property_unik(_config, unik_property_number, admin_id) do
+  def create_synced_property_unik(_config, property_number, company_number, admin_id) do
     call_and_get_mock_value(:create_synced_property_unik, %{
-      unik_property_number: unik_property_number,
+      property_number: property_number,
+      company_number: company_number,
       admin_id: admin_id
     })
   end


### PR DESCRIPTION
Changed attrs in unik sync from `[number]` to `[property_number, company_number]`, as it is changed in the API.