### PR TITLE
Added unconfigurable_reason to ConfigurableMeterID

### DIFF
--- a/lib/wise_homex/models/configurable_meter_id.ex
+++ b/lib/wise_homex/models/configurable_meter_id.ex
@@ -9,6 +9,7 @@ defmodule WiseHomex.ConfigurableMeterID do
     field(:serial, :string)
     field(:version, :integer)
     field(:configurable, :boolean)
+    field(:unconfigurable_reason, :string)
     embeds_one(:manufacturer, WiseHomex.WMBusManufacturer)
     embeds_one(:device_type, WiseHomex.WMBusDeviceType)
   end


### PR DESCRIPTION
This is needed to show _why_ a wmbus meter is not configurable.