### PR TITLE
52 parse dates

### DIFF
--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -224,8 +224,9 @@ defmodule WiseHomex.JSONParser do
     |> set_struct_attribute(id_key, related_struct.id)
   end
 
-  defp add_related_entity(_key, nil, struct) do
+  defp add_related_entity(key, nil, struct) do
     struct
+    |> set_struct_attribute(key, nil)
   end
 
   defp add_related_entity(key, list, struct) when is_list(list) do

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -262,7 +262,7 @@ defmodule WiseHomex.JSONParser do
     fields = module.__changeset__()
 
     case Map.fetch(fields, key) do
-      {:ok, :date} -> coerce_struct_value(struct, key, value)
+      {:ok, type} when type in [:date, :utc_datetime] -> coerce_struct_value(struct, key, value)
       {:ok, _} -> %{struct | key => value}
       _ -> struct
     end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -670,4 +670,20 @@ defmodule WiseHomex.JSONParserTest do
 
     assert tenancy.move_in_date == ~D[2019-08-19]
   end
+
+  test "parse datetimes as DateTime" do
+    data = %{
+      "data" => %{
+        "type" => "users",
+        "id" => "45",
+        "attributes" => %{
+          "activated-at" => "2019-08-19T15:28:00.000000Z"
+        }
+      }
+    }
+
+    user = JSONParser.parse(data)
+
+    assert user.activated_at == ~N[2019-08-19 15:28:00] |> DateTime.from_naive!("Etc/UTC")
+  end
 end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -649,4 +649,25 @@ defmodule WiseHomex.JSONParserTest do
 
     assert account.id == "1"
   end
+
+  test "parse dates as Date" do
+    json = """
+    {
+      "data": {
+        "type": "tenancies",
+        "id": "a2d75bd4-c0a8-4316-8592-df4ac86774b8",
+        "attributes": {
+          "move-in-date": "2019-08-19"
+        }
+      }
+    }
+    """
+
+    tenancy =
+      json
+      |> Jason.decode!()
+      |> JSONParser.parse()
+
+    assert tenancy.move_in_date == ~D[2019-08-19]
+  end
 end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -686,4 +686,19 @@ defmodule WiseHomex.JSONParserTest do
 
     assert user.activated_at == ~N[2019-08-19 15:28:00] |> DateTime.from_naive!("Etc/UTC")
   end
+
+  test "sets relations to nil if they are nil" do
+    data = %{
+      "data" => %{
+        "type" => "households",
+        "id" => "1",
+        "relationships" => %{
+          "tenant" => %{"data" => nil}
+        }
+      }
+    }
+
+    household = JSONParser.parse(data)
+    assert household.tenant == nil
+  end
 end


### PR DESCRIPTION
Closes #52 

Parses `:date` and `utc_datetime` types correctly as Date and DateTime in the `JSONParser`.
Note that this is a breaking change, since calling code might depend on the fields containing strings.