### PR TITLE
Parses signal_strength_history as an embed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,39 +95,6 @@ jobs:
           ERLANG_VERSION: "21.2.7"
           CACHE_VERSION: "v1"
 
-  "elixir 1.8 - erlang 22.0":
-    <<: *default_build
-    docker:
-      # This version of Elixir is overruled by asdf
-      - image: circleci/elixir:1.8
-        environment:
-          <<: *default_env
-          ELIXIR_VERSION: "1.8.2-otp-22"
-          ERLANG_VERSION: "22.0.7"
-          CACHE_VERSION: "v1"
-
-  "elixir 1.8 - erlang 21.3":
-    <<: *default_build
-    docker:
-      # This version of Elixir is overruled by asdf
-      - image: circleci/elixir:1.8
-        environment:
-          <<: *default_env
-          ELIXIR_VERSION: "1.8.2-otp-21"
-          ERLANG_VERSION: "21.3.8"
-          CACHE_VERSION: "v1"
-
-  "elixir 1.8 - erlang 21.2":
-    <<: *default_build
-    docker:
-      # This version of Elixir is overruled by asdf
-      - image: circleci/elixir:1.8
-        environment:
-          <<: *default_env
-          ELIXIR_VERSION: "1.8.2-otp-21"
-          ERLANG_VERSION: "21.2.7"
-          CACHE_VERSION: "v1"
-
 workflows:
   version: 2
   "elixir 1.9 - erlang 22.0":
@@ -141,15 +108,3 @@ workflows:
   "elixir 1.9 - erlang 21.2":
     jobs:
       - "elixir 1.9 - erlang 21.2"
-
-  "elixir 1.8 - erlang 22.0":
-    jobs:
-      - "elixir 1.8 - erlang 22.0"
-
-  "elixir 1.8 - erlang 21.3":
-    jobs:
-      - "elixir 1.8 - erlang 21.3"
-
-  "elixir 1.8 - erlang 21.2":
-    jobs:
-      - "elixir 1.8 - erlang 21.2"

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ end
 
 ## Versions of Elixir and Erlang
 
-WiseHomex will be tested against the two latest minor versions of Elixir and the three latest minor versions of Erlang.
+WiseHomex will be tested against the two latest minor versions of Elixir (but >= 1.9) and the three latest minor versions of Erlang.
 In all cases the latest patch version is used.
 
 E.g. if the latest Elixir is 1.9.1 and the latest Erlang is 22.0.7, we test against:
 
-* Elixir: 1.9.1 and 1.8.2
+* Elixir: 1.9.1
 * Erlang: 22.0.7, 21.3.8 and 21.2.7

--- a/lib/wise_homex/models/device.ex
+++ b/lib/wise_homex/models/device.ex
@@ -15,8 +15,12 @@ defmodule WiseHomex.Device do
     field(:last_seen, :utc_datetime)
     field(:inserted_at, :utc_datetime)
     field(:signal_strength, :integer)
-    field(:signal_strength_history, {:array, :map})
     field(:protocol, :string)
+
+    embeds_many :signal_strength_history, Signal, primary_key: false do
+      field(:time, :utc_datetime)
+      field(:signal_strength, :integer)
+    end
   end
 
   def household_id(%__MODULE__{room: %{household: %{id: id}}}), do: id

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -701,4 +701,26 @@ defmodule WiseHomex.JSONParserTest do
     household = JSONParser.parse(data)
     assert household.tenant == nil
   end
+
+  test "parsing embed" do
+    data = %{
+      "data" => %{
+        "type" => "devices",
+        "id" => "1",
+        "attributes" => %{
+          "signal-strength-history" => [
+            %{"time" => "2019-08-21T23:58:00Z", "signal-strength" => -88},
+            %{"time" => "2019-08-21T23:59:00Z", "signal-strength" => -87}
+          ]
+        }
+      }
+    }
+
+    device = JSONParser.parse(data)
+
+    assert device.signal_strength_history == [
+             %Device.Signal{time: ~U[2019-08-21 23:58:00Z], signal_strength: -88},
+             %Device.Signal{time: ~U[2019-08-21 23:59:00Z], signal_strength: -87}
+           ]
+  end
 end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -684,7 +684,7 @@ defmodule WiseHomex.JSONParserTest do
 
     user = JSONParser.parse(data)
 
-    assert user.activated_at == ~N[2019-08-19 15:28:00] |> DateTime.from_naive!("Etc/UTC")
+    assert user.activated_at == ~U[2019-08-19 15:28:00Z]
   end
 
   test "sets relations to nil if they are nil" do


### PR DESCRIPTION
In https://github.com/wise-home/wise_homex/pull/53 we parse dates and datetimes correctly. However we missed the `time` subfield of `signal_strength_history` of Device.

This allows for correct parsing of the datetime field inside the `signal_strength_history`.