### PR TITLE
Add query to get_settlement_key to be able to include relations

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -503,7 +503,7 @@ defmodule WiseHomex do
   @doc """
   Get SettlementKey by id
   """
-  def get_settlement_key(config, id), do: api_client().get_settlement_key(config, id)
+  def get_settlement_key(config, id, query \\ %{}), do: api_client().get_settlement_key(config, id, query)
 
   @doc """
   List SettlementKeys

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -121,7 +121,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback update_room(Config.t(), id, attributes, relationships) :: response
 
   # SettlementKey
-  @callback get_settlement_key(Config.t(), id) :: response
+  @callback get_settlement_key(Config.t(), id, query) :: response
   @callback get_settlement_keys(Config.t(), query) :: response
   @callback create_settlement_key(Config.t(), attributes, relationships) :: response
   @callback update_settlement_key(Config.t(), id, attributes) :: response

--- a/lib/wise_homex/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl.ex
@@ -675,8 +675,8 @@ defmodule WiseHomex.ApiClientImpl do
   end
 
   # SettlementKey
-  def get_settlement_key(config, id) do
-    Request.get(config, "/settlement-keys/#{id}")
+  def get_settlement_key(config, id, query \\ %{}) do
+    Request.get(config, "/settlement-keys/#{id}", query)
   end
 
   def get_settlement_keys(config, query) do

--- a/lib/wise_homex/test/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock.ex
@@ -315,8 +315,8 @@ defmodule WiseHomex.Test.ApiClientMock do
   end
 
   # SettlementKey
-  def get_settlement_key(_config, id) do
-    call_and_get_mock_value(:get_settlement_key, %{id: id})
+  def get_settlement_key(_config, id, query \\ %{}) do
+    call_and_get_mock_value(:get_settlement_key, %{id: id, query: query})
   end
 
   def get_settlement_keys(_config, query) do


### PR DESCRIPTION
It's now possible to add an `include` to `get_settlement_key`