### PR TITLE
Use default ecto format without parenthesis in schema spec, 57

### DIFF
--- a/lib/wise_homex/models/account.ex
+++ b/lib/wise_homex/models/account.ex
@@ -4,17 +4,17 @@ defmodule WiseHomex.Account do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:owner, __MODULE__)
-    has_many(:tenancies, WiseHomex.Tenancy, foreign_key: :tenant_id)
-    has_many(:admin_integrations, WiseHomex.AdminIntegration, foreign_key: :admin_id)
+    belongs_to :owner, __MODULE__
+    has_many :tenancies, WiseHomex.Tenancy, foreign_key: :tenant_id
+    has_many :admin_integrations, WiseHomex.AdminIntegration, foreign_key: :admin_id
 
-    field(:name, :string)
-    field(:role, :string)
-    field(:email, :string)
-    field(:phone, :string)
+    field :name, :string
+    field :role, :string
+    field :email, :string
+    field :phone, :string
 
     embeds_one :email_settings, EmailSettings do
-      field(:ventilation_alarm, :boolean)
+      field :ventilation_alarm, :boolean
     end
   end
 end

--- a/lib/wise_homex/models/account_user.ex
+++ b/lib/wise_homex/models/account_user.ex
@@ -4,8 +4,8 @@ defmodule WiseHomex.AccountUser do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:account, WiseHomex.Account)
-    belongs_to(:user, WiseHomex.User)
-    field(:api_key, :string)
+    belongs_to :account, WiseHomex.Account
+    belongs_to :user, WiseHomex.User
+    field :api_key, :string
   end
 end

--- a/lib/wise_homex/models/address.ex
+++ b/lib/wise_homex/models/address.ex
@@ -4,13 +4,13 @@ defmodule WiseHomex.Address do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:property, WiseHomex.Property)
-    has_many(:households, WiseHomex.Household)
+    belongs_to :property, WiseHomex.Property
+    has_many :households, WiseHomex.Household
 
-    field(:street_and_number, :string)
-    field(:place, :string)
-    field(:zip_code, :string)
-    field(:city, :string)
-    field(:country_code_alpha3, :string)
+    field :street_and_number, :string
+    field :place, :string
+    field :zip_code, :string
+    field :city, :string
+    field :country_code_alpha3, :string
   end
 end

--- a/lib/wise_homex/models/admin_integration.ex
+++ b/lib/wise_homex/models/admin_integration.ex
@@ -4,9 +4,9 @@ defmodule WiseHomex.AdminIntegration do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:admin, WiseHomex.Account)
+    belongs_to :admin, WiseHomex.Account
 
-    field(:integration_type, :string)
-    field(:config, :map)
+    field :integration_type, :string
+    field :config, :map
   end
 end

--- a/lib/wise_homex/models/angel_note.ex
+++ b/lib/wise_homex/models/angel_note.ex
@@ -4,9 +4,9 @@ defmodule WiseHomex.AngelNote do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:target_type, :string)
-    field(:target_id, :string)
-    field(:content, :string)
-    timestamps(type: :utc_datetime)
+    field :target_type, :string
+    field :target_id, :string
+    field :content, :string
+    timestamps type: :utc_datetime
   end
 end

--- a/lib/wise_homex/models/configurable_meter_id.ex
+++ b/lib/wise_homex/models/configurable_meter_id.ex
@@ -6,11 +6,11 @@ defmodule WiseHomex.ConfigurableMeterID do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:serial, :string)
-    field(:version, :integer)
-    field(:configurable, :boolean)
-    field(:unconfigurable_reason, :string)
-    embeds_one(:manufacturer, WiseHomex.WMBusManufacturer)
-    embeds_one(:device_type, WiseHomex.WMBusDeviceType)
+    field :serial, :string
+    field :version, :integer
+    field :configurable, :boolean
+    field :unconfigurable_reason, :string
+    embeds_one :manufacturer, WiseHomex.WMBusManufacturer
+    embeds_one :device_type, WiseHomex.WMBusDeviceType
   end
 end

--- a/lib/wise_homex/models/configurable_meters.ex
+++ b/lib/wise_homex/models/configurable_meters.ex
@@ -6,7 +6,7 @@ defmodule WiseHomex.ConfigurableMeters do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:updated_at, :utc_datetime)
-    embeds_many(:meters, WiseHomex.ConfigurableMeterID)
+    field :updated_at, :utc_datetime
+    embeds_many :meters, WiseHomex.ConfigurableMeterID
   end
 end

--- a/lib/wise_homex/models/device.ex
+++ b/lib/wise_homex/models/device.ex
@@ -4,22 +4,22 @@ defmodule WiseHomex.Device do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:room, WiseHomex.Room)
-    belongs_to(:gateway, WiseHomex.Gateway)
-    belongs_to(:device_type, WiseHomex.DeviceType)
-    field(:serial, :string)
-    field(:number, :string)
-    field(:authorized_at, :utc_datetime)
-    field(:online, :string)
-    field(:installation_year, :integer)
-    field(:last_seen, :utc_datetime)
-    field(:inserted_at, :utc_datetime)
-    field(:signal_strength, :integer)
-    field(:protocol, :string)
+    belongs_to :room, WiseHomex.Room
+    belongs_to :gateway, WiseHomex.Gateway
+    belongs_to :device_type, WiseHomex.DeviceType
+    field :serial, :string
+    field :number, :string
+    field :authorized_at, :utc_datetime
+    field :online, :string
+    field :installation_year, :integer
+    field :last_seen, :utc_datetime
+    field :inserted_at, :utc_datetime
+    field :signal_strength, :integer
+    field :protocol, :string
 
     embeds_many :signal_strength_history, Signal, primary_key: false do
-      field(:time, :utc_datetime)
-      field(:signal_strength, :integer)
+      field :time, :utc_datetime
+      field :signal_strength, :integer
     end
   end
 

--- a/lib/wise_homex/models/device_authorization.ex
+++ b/lib/wise_homex/models/device_authorization.ex
@@ -4,6 +4,6 @@ defmodule WiseHomex.DeviceAuthorization do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:device, WiseHomex.Device)
+    belongs_to :device, WiseHomex.Device
   end
 end

--- a/lib/wise_homex/models/device_type.ex
+++ b/lib/wise_homex/models/device_type.ex
@@ -4,11 +4,11 @@ defmodule WiseHomex.DeviceType do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:system_name, :string)
-    field(:protocol, :string)
-    field(:power_source, :string)
-    field(:name, :string)
-    field(:manufacturer, :string)
-    field(:kind, :string)
+    field :system_name, :string
+    field :protocol, :string
+    field :power_source, :string
+    field :name, :string
+    field :manufacturer, :string
+    field :kind, :string
   end
 end

--- a/lib/wise_homex/models/enc_key.ex
+++ b/lib/wise_homex/models/enc_key.ex
@@ -4,7 +4,7 @@ defmodule WiseHomex.EncKey do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:manufacturer, :string)
-    field(:serial, :string)
+    field :manufacturer, :string
+    field :serial, :string
   end
 end

--- a/lib/wise_homex/models/external_info.ex
+++ b/lib/wise_homex/models/external_info.ex
@@ -4,9 +4,9 @@ defmodule WiseHomex.ExternalInfo do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:system, :string)
-    field(:number, :string)
-    field(:synced, :boolean)
-    field(:last_synced_at, :utc_datetime)
+    field :system, :string
+    field :number, :string
+    field :synced, :boolean
+    field :last_synced_at, :utc_datetime
   end
 end

--- a/lib/wise_homex/models/firmware.ex
+++ b/lib/wise_homex/models/firmware.ex
@@ -4,10 +4,10 @@ defmodule WiseHomex.Firmware do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:manufacturer_code, :string)
-    field(:image_type, :string)
-    field(:file_version, :string)
+    field :manufacturer_code, :string
+    field :image_type, :string
+    field :file_version, :string
 
-    timestamps()
+    timestamps type: :utc_datetime
   end
 end

--- a/lib/wise_homex/models/gateway.ex
+++ b/lib/wise_homex/models/gateway.ex
@@ -4,18 +4,18 @@ defmodule WiseHomex.Gateway do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:admin, WiseHomex.Account)
-    belongs_to(:sim, WiseHomex.Sim)
-    field(:serial, :string)
-    field(:address, :string)
-    field(:location, :string)
-    field(:notes, :string)
-    field(:last_connect_at, :utc_datetime)
-    field(:software_version, :string)
-    field(:online, :string)
-    field(:unlocked_at, :utc_datetime)
-    field(:unlocked_seconds, :integer)
-    field(:enabled_modules, {:array, :string}, default: [])
-    field(:skip_offline_report, :boolean)
+    belongs_to :admin, WiseHomex.Account
+    belongs_to :sim, WiseHomex.Sim
+    field :serial, :string
+    field :address, :string
+    field :location, :string
+    field :notes, :string
+    field :last_connect_at, :utc_datetime
+    field :software_version, :string
+    field :online, :string
+    field :unlocked_at, :utc_datetime
+    field :unlocked_seconds, :integer
+    field :enabled_modules, {:array, :string}, default: []
+    field :skip_offline_report, :boolean
   end
 end

--- a/lib/wise_homex/models/household.ex
+++ b/lib/wise_homex/models/household.ex
@@ -4,15 +4,15 @@ defmodule WiseHomex.Household do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:tenant, WiseHomex.Account)
-    belongs_to(:address, WiseHomex.Address, type: :binary_id)
-    belongs_to(:external_info, WiseHomex.ExternalInfo)
-    has_many(:tenancies, WiseHomex.Tenancy)
-    has_many(:settlement_values, WiseHomex.SettlementValue)
+    belongs_to :tenant, WiseHomex.Account
+    belongs_to :address, WiseHomex.Address, type: :binary_id
+    belongs_to :external_info, WiseHomex.ExternalInfo
+    has_many :tenancies, WiseHomex.Tenancy
+    has_many :settlement_values, WiseHomex.SettlementValue
 
-    field(:apartment, :string)
-    field(:active_from, :date)
-    field(:active_to, :date)
-    field(:active, :boolean)
+    field :apartment, :string
+    field :active_from, :date
+    field :active_to, :date
+    field :active, :boolean
   end
 end

--- a/lib/wise_homex/models/kem_info.ex
+++ b/lib/wise_homex/models/kem_info.ex
@@ -6,6 +6,6 @@ defmodule WiseHomex.KEMInfo do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:serial, :string)
+    field :serial, :string
   end
 end

--- a/lib/wise_homex/models/latest_report.ex
+++ b/lib/wise_homex/models/latest_report.ex
@@ -4,7 +4,7 @@ defmodule WiseHomex.LatestReport do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:device, WiseHomex.Device)
-    embeds_many(:measurements, WiseHomex.Measurement)
+    belongs_to :device, WiseHomex.Device
+    embeds_many :measurements, WiseHomex.Measurement
   end
 end

--- a/lib/wise_homex/models/measurement.ex
+++ b/lib/wise_homex/models/measurement.ex
@@ -4,12 +4,12 @@ defmodule WiseHomex.Measurement do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:measurement_at, :utc_datetime)
-    field(:meter_type, :string)
+    field :measurement_at, :utc_datetime
+    field :meter_type, :string
 
-    field(:value, :integer)
+    field :value, :integer
     # Base 10
-    field(:exponent, :integer)
-    field(:unit, :string)
+    field :exponent, :integer
+    field :unit, :string
   end
 end

--- a/lib/wise_homex/models/message_report.ex
+++ b/lib/wise_homex/models/message_report.ex
@@ -6,9 +6,9 @@ defmodule WiseHomex.MessageReport do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:name, :string)
-    field(:started_at, :string)
-    field(:stopped_at, :string)
-    field(:events, {:array, :string})
+    field :name, :string
+    field :started_at, :string
+    field :stopped_at, :string
+    field :events, {:array, :string}
   end
 end

--- a/lib/wise_homex/models/pong.ex
+++ b/lib/wise_homex/models/pong.ex
@@ -6,9 +6,9 @@ defmodule WiseHomex.Pong do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:message, :string)
-    field(:version, :string)
-    belongs_to(:user, WiseHomex.User)
-    belongs_to(:account, WiseHomex.Account)
+    field :message, :string
+    field :version, :string
+    belongs_to :user, WiseHomex.User
+    belongs_to :account, WiseHomex.Account
   end
 end

--- a/lib/wise_homex/models/property.ex
+++ b/lib/wise_homex/models/property.ex
@@ -4,12 +4,12 @@ defmodule WiseHomex.Property do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:admin, WiseHomex.Account)
-    belongs_to(:external_info, WiseHomex.ExternalInfo)
-    has_many(:addresses, WiseHomex.Address)
+    belongs_to :admin, WiseHomex.Account
+    belongs_to :external_info, WiseHomex.ExternalInfo
+    has_many :addresses, WiseHomex.Address
 
-    field(:name, :string)
-    field(:legal_name, :string)
-    field(:number, :integer)
+    field :name, :string
+    field :legal_name, :string
+    field :number, :integer
   end
 end

--- a/lib/wise_homex/models/room.ex
+++ b/lib/wise_homex/models/room.ex
@@ -4,7 +4,7 @@ defmodule WiseHomex.Room do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:household, WiseHomex.Household)
-    field(:name, :string)
+    belongs_to :household, WiseHomex.Household
+    field :name, :string
   end
 end

--- a/lib/wise_homex/models/settlement_key.ex
+++ b/lib/wise_homex/models/settlement_key.ex
@@ -7,9 +7,9 @@ defmodule WiseHomex.SettlementKey do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:admin, WiseHomex.Account)
-    belongs_to(:property, WiseHomex.Property)
-    field(:name, :string)
-    field(:unit, :string)
+    belongs_to :admin, WiseHomex.Account
+    belongs_to :property, WiseHomex.Property
+    field :name, :string
+    field :unit, :string
   end
 end

--- a/lib/wise_homex/models/sim.ex
+++ b/lib/wise_homex/models/sim.ex
@@ -4,13 +4,13 @@ defmodule WiseHomex.Sim do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    has_one(:gateway, WiseHomex.Gateway)
-    field(:icc_id, :string)
-    field(:phone_number, :string)
-    field(:notes, :string)
-    field(:unavailable, :boolean)
-    field(:public_ip, :boolean)
-    field(:provider, :string)
-    field(:inactive, :boolean)
+    has_one :gateway, WiseHomex.Gateway
+    field :icc_id, :string
+    field :phone_number, :string
+    field :notes, :string
+    field :unavailable, :boolean
+    field :public_ip, :boolean
+    field :provider, :string
+    field :inactive, :boolean
   end
 end

--- a/lib/wise_homex/models/tenancy.ex
+++ b/lib/wise_homex/models/tenancy.ex
@@ -4,12 +4,12 @@ defmodule WiseHomex.Tenancy do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    belongs_to(:external_info, WiseHomex.ExternalInfo)
-    belongs_to(:household, WiseHomex.Household)
-    belongs_to(:tenant, WiseHomex.Account)
+    belongs_to :external_info, WiseHomex.ExternalInfo
+    belongs_to :household, WiseHomex.Household
+    belongs_to :tenant, WiseHomex.Account
 
-    field(:move_in_date, :date)
-    field(:move_out_date, :date)
+    field :move_in_date, :date
+    field :move_out_date, :date
   end
 
   @doc """

--- a/lib/wise_homex/models/user.ex
+++ b/lib/wise_homex/models/user.ex
@@ -4,9 +4,9 @@ defmodule WiseHomex.User do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:name, :string)
-    field(:email, :string)
-    field(:activated_at, :utc_datetime)
-    field(:activation_token, :string)
+    field :name, :string
+    field :email, :string
+    field :activated_at, :utc_datetime
+    field :activation_token, :string
   end
 end

--- a/lib/wise_homex/models/wmbus_device_type.ex
+++ b/lib/wise_homex/models/wmbus_device_type.ex
@@ -6,6 +6,6 @@ defmodule WiseHomex.WMBusDeviceType do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:name, :string)
+    field :name, :string
   end
 end

--- a/lib/wise_homex/models/wmbus_manufacturer.ex
+++ b/lib/wise_homex/models/wmbus_manufacturer.ex
@@ -6,7 +6,7 @@ defmodule WiseHomex.WMBusManufacturer do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field(:name, :string)
-    field(:en_61107, :string)
+    field :name, :string
+    field :en_61107, :string
   end
 end


### PR DESCRIPTION
Closes #57 

Only syntax changes. Now uses default ecto format without parenthesis in the schema definitions.