### PR TITLE
Change interface of set_device_location

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -254,7 +254,8 @@ defmodule WiseHomex do
   @doc """
   Set device location
   """
-  def set_device_location(config, device_id, room_id), do: api_client().set_device_location(config, device_id, room_id)
+  def set_device_location(config, device_id, attrs, rels),
+    do: api_client().set_device_location(config, device_id, attrs, rels)
 
   @doc """
   Unset device location

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -56,7 +56,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback fast_ping_device(Config.t(), id) :: response
   @callback get_device(Config.t(), id, query) :: response
   @callback get_devices(Config.t(), query) :: response
-  @callback set_device_location(Config.t(), id, id) :: response
+  @callback set_device_location(Config.t(), id, attributes, relationships) :: response
   @callback unset_device_location(Config.t(), id) :: response
   @callback update_device(Config.t(), id, attributes, relationships) :: response
 

--- a/lib/wise_homex/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl.ex
@@ -243,19 +243,18 @@ defmodule WiseHomex.ApiClientImpl do
     Request.get(config, "/devices", query)
   end
 
-  def set_device_location(config, device_id, room_id) do
+  def set_device_location(config, device_id, attrs, rels) do
     payload =
       %{
         data: %{
           type: "device-locations",
-          relationships: %{
-            room: %{data: %{type: "rooms", id: room_id}}
-          }
+          attributes: attrs,
+          relationships: rels
         }
       }
       |> normalize_payload()
 
-    Request.post(config, "/devices/" <> device_id <> "/location", payload)
+    Request.post(config, "/devices/#{device_id}/location", payload)
   end
 
   def unset_device_location(config, device_id) do

--- a/lib/wise_homex/test/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock.ex
@@ -128,8 +128,8 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:get_devices, %{query: query})
   end
 
-  def set_device_location(_config, device_id, room_id) do
-    call_and_get_mock_value(:set_device_location, %{device_id: device_id, room_id: room_id})
+  def set_device_location(_config, device_id, attrs, rels) do
+    call_and_get_mock_value(:set_device_location, %{device_id: device_id, attrs: attrs, rels: rels})
   end
 
   def unset_device_location(_config, device_id) do


### PR DESCRIPTION
We now need to send attrs in set_device_location, so the api function was changed to follow the standard of accepting attrs and rels.