### PR TITLE
Rename wmbus serials to number

### DIFF
--- a/lib/wise_homex/models/configurable_meter_id.ex
+++ b/lib/wise_homex/models/configurable_meter_id.ex
@@ -6,7 +6,7 @@ defmodule WiseHomex.ConfigurableMeterID do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field :serial, :string
+    field :number, :string
     field :version, :integer
     field :configurable, :boolean
     field :unconfigurable_reason, :string

--- a/lib/wise_homex/models/enc_key.ex
+++ b/lib/wise_homex/models/enc_key.ex
@@ -5,6 +5,6 @@ defmodule WiseHomex.EncKey do
 
   embedded_schema do
     field :manufacturer, :string
-    field :serial, :string
+    field :number, :string
   end
 end

--- a/lib/wise_homex/models/kem_info.ex
+++ b/lib/wise_homex/models/kem_info.ex
@@ -6,6 +6,6 @@ defmodule WiseHomex.KEMInfo do
   use WiseHomex.BaseModel
 
   embedded_schema do
-    field :serial, :string
+    field :number, :string
   end
 end


### PR DESCRIPTION
In the API, wmbus serials have been renamed to number to not confuse them with our serials.