### PR TITLE
Parse MessageReports with correct utc_datetimes, 72

### DIFF
--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -306,13 +306,19 @@ defmodule WiseHomex.JSONParser do
   end
 
   # If it's a map of attributes, it does not have it's own json-api type. Parse it to the given Ecto module
-  defp parse_embed(module, attributes) do
+  defp parse_embed(module, %{} = attributes) do
     struct = struct(module)
 
     attributes
     |> Enum.reduce(struct, fn {key, value}, struct ->
       set_struct_attribute(struct, transform_key(key), value)
     end)
+  end
+
+  # If it's something else, it must be able to parse itself
+  defp parse_embed(module, data) do
+    {:ok, model} = module.cast(data)
+    model
   end
 
   defp parse_required_entities(data) do

--- a/lib/wise_homex/models/message_report.ex
+++ b/lib/wise_homex/models/message_report.ex
@@ -7,8 +7,8 @@ defmodule WiseHomex.MessageReport do
 
   embedded_schema do
     field :name, :string
-    field :started_at, :string
-    field :stopped_at, :string
-    field :events, {:array, :string}
+    field :started_at, :utc_datetime
+    field :stopped_at, :utc_datetime
+    embeds_many :events, WiseHomex.MessageReport.Event
   end
 end

--- a/lib/wise_homex/models/message_report/event.ex
+++ b/lib/wise_homex/models/message_report/event.ex
@@ -1,0 +1,39 @@
+defmodule WiseHomex.MessageReport.Event do
+  @moduledoc """
+  Embedded type under MessageReport. This has a custom Ecto type, since it is rendered as a length-two list from the
+  API.
+  """
+
+  use WiseHomex.BaseModel
+  use Ecto.Type
+
+  alias Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    field :description, :string
+    field :time, :utc_datetime
+  end
+
+  @impl Ecto.Type
+  def cast(%__MODULE__{} = event), do: {:ok, event}
+
+  def cast([description, time]) do
+    %__MODULE__{}
+    |> Changeset.cast(%{description: description, time: time}, [:description, :time])
+    |> case do
+      %{valid?: true} = changeset -> {:ok, Changeset.apply_changes(changeset)}
+      %{valid?: false} -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  @impl Ecto.Type
+  def dump(_), do: {:ok, nil}
+  @impl Ecto.Type
+  def load(_), do: {:ok, nil}
+  @impl Ecto.Type
+  def type, do: nil
+end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -723,4 +723,33 @@ defmodule WiseHomex.JSONParserTest do
              %Device.Signal{time: ~U[2019-08-21 23:59:00Z], signal_strength: -87}
            ]
   end
+
+  test "parsing MessageReport" do
+    data = %{
+      "data" => [
+        %{
+          "attributes" => %{
+            "events" => [
+              ["Waiting for device to become responsive", "2019-09-27T20:14:23.942737Z"]
+            ],
+            "name" => "Fast ping",
+            "started-at" => "2019-09-27T20:14:23.942389Z",
+            "stopped-at" => "2019-09-27T20:23:53.450495Z"
+          },
+          "id" => "",
+          "type" => "message-reports"
+        }
+      ],
+      "jsonapi" => %{"version" => "1.0"}
+    }
+
+    [report] = JSONParser.parse(data)
+
+    [event] = report.events
+    assert event.description == "Waiting for device to become responsive"
+    assert event.time == ~U[2019-09-27 20:14:23Z]
+    assert report.name == "Fast ping"
+    assert report.started_at == ~U[2019-09-27 20:14:23Z]
+    assert report.stopped_at == ~U[2019-09-27 20:23:53Z]
+  end
 end


### PR DESCRIPTION
Closes #72 

* Use `utc_datetime` for MessageReport times
* Add Event under MessageReport to parse event time correctly
