### PR TITLE
Faster json parsing

### DIFF
--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -273,20 +273,8 @@ defmodule WiseHomex.JSONParser do
         # Convert embedded value
         convert_ecto_embedded_value(struct, embedded_type, key, value)
 
-      {:ok, type} when type in [:date, :utc_datetime] ->
-        # Convert Date and DateTime
-        convert_ecto_value(struct, key, value)
-
       {:ok, type} when is_atom(type) ->
-        Code.ensure_loaded(type)
-
-        if function_exported?(type, :cast, 1) do
-          # Convert Ecto.Type
-          convert_ecto_value(struct, key, value)
-        else
-          # Otherwise just set the value
-          %{struct | key => value}
-        end
+        convert_ecto_value(struct, key, value)
 
       {:ok, _} ->
         # Otherwise just set the value

--- a/lib/wise_homex/models/base_model.ex
+++ b/lib/wise_homex/models/base_model.ex
@@ -11,6 +11,7 @@ defmodule WiseHomex.BaseModel do
 
       use Ecto.Schema
       @primary_key {:id, :string, autogenerate: false}
+      @foreign_key_type :string
     end
   end
 end


### PR DESCRIPTION
Removed a `Code.ensure_loaded/1` call for each attribute that is set. It was used to only cast values that was in defined as an ecto type. Now we cast all attributes and have also set the default id type to string.

Note that the slowness only showed in dev and not in stag or prod, where `Code.ensure_loaded/1` is probably optimized somehow.