### PR TITLE
Fix casting of PostalAddress, 95

### DIFF
--- a/lib/wise_homex/models/postal_address.ex
+++ b/lib/wise_homex/models/postal_address.ex
@@ -34,17 +34,16 @@ defmodule WiseHomex.PostalAddress do
 
   def cast(%__MODULE__{} = postal_address), do: {:ok, postal_address}
 
-  def cast(%{address: address, zip_code: zip_code, city: city, country_code_alpha3: country_code_alpha3}) do
-    {:ok, new(address, zip_code, city, country_code_alpha3)}
-  end
+  def cast(%{} = map) do
+    map
+    |> Enum.into(%{}, fn {key, value} -> {cast_map_key(key), value} end)
+    |> case do
+      %{address: address, zip_code: zip_code, city: city, country_code_alpha3: country_code_alpha3} ->
+        {:ok, new(address, zip_code, city, country_code_alpha3)}
 
-  def cast(%{
-        "address" => address,
-        "zip_code" => zip_code,
-        "city" => city,
-        "country_code_alpha3" => country_code_alpha3
-      }) do
-    {:ok, new(address, zip_code, city, country_code_alpha3)}
+      _ ->
+        :error
+    end
   end
 
   def cast(_), do: :error
@@ -53,4 +52,8 @@ defmodule WiseHomex.PostalAddress do
   def dump(postal_address), do: {:ok, postal_address}
   def load(data), do: {:ok, data}
   def type, do: :map
+
+  defp cast_map_key(atom) when is_atom(atom), do: atom
+  defp cast_map_key(string) when is_binary(string), do: string |> String.replace("-", "_") |> String.to_existing_atom()
+  defp cast_map_key(key), do: key
 end

--- a/test/json_parser_test.exs
+++ b/test/json_parser_test.exs
@@ -763,8 +763,8 @@ defmodule WiseHomex.JSONParserTest do
           "postal-address" => %{
             "address" => "Storegade 42",
             "city" => "Aarhus C",
-            "country_code_alpha3" => "DNK",
-            "zip_code" => "8000"
+            "country-code-alpha3" => "DNK",
+            "zip-code" => "8000"
           }
         }
       }


### PR DESCRIPTION
Closes #95 

The key was fixed in the API to use kebab-case instead of snake_case. This change reflects that.