### PR TITLE
Support for radiator :info field

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -282,12 +282,6 @@ defmodule WiseHomex do
   """
   def import_devices(config, attrs, rels), do: api_client().import_devices(config, attrs, rels)
 
-  # Radiator
-
-  def get_radiator(config, id, query \\ %{}), do: api_client().get_radiator(config, id, query)
-  def get_radiators(config, query \\ %{}), do: api_client().get_radiators(config, query)
-  def import_radiators(config, attrs), do: api_client().import_radiators(config, attrs)
-
   # Email Settings
 
   @doc """
@@ -519,6 +513,30 @@ defmodule WiseHomex do
   """
   def create_latest_report(config, device_id, query \\ %{}),
     do: api_client().create_latest_report(config, device_id, query)
+
+  # Radiator
+
+  @doc """
+  Get a radiator
+  """
+  def get_radiator(config, id, query \\ %{}), do: api_client().get_radiator(config, id, query)
+
+  @doc """
+  Get multiple radiators
+  """
+  def get_radiators(config, query \\ %{}), do: api_client().get_radiators(config, query)
+
+  @doc """
+  Import radiators
+  """
+  def import_radiators(config, attrs), do: api_client().import_radiators(config, attrs)
+
+  # Radiator Info
+
+  @doc """
+  Get an url to info about a radiator
+  """
+  def get_radiator_info(config, id), do: api_client().get_radiator_info(config, id)
 
   # Room
 

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -62,11 +62,6 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback update_device(Config.t(), id, attributes, relationships) :: response
   @callback import_devices(Config.t(), attributes, relationships) :: response
 
-  # Radiators
-  @callback get_radiator(Config.t(), id, query) :: response
-  @callback get_radiators(Config.t(), query) :: response
-  @callback import_radiators(Config.t(), attributes) :: response
-
   # Email Settings
   @callback update_account_email_settings(Config.t(), id, id, attributes) :: response
 
@@ -128,6 +123,14 @@ defmodule WiseHomex.ApiClientBehaviour do
 
   # Property Syncs UNIK
   @callback create_synced_property_unik(Config.t(), unik_number, unik_number, id) :: response
+
+  # Radiators
+  @callback get_radiator(Config.t(), id, query) :: response
+  @callback get_radiators(Config.t(), query) :: response
+  @callback import_radiators(Config.t(), attributes) :: response
+
+  # Radiator Info
+  @callback get_radiator_info(Config.t(), id) :: response
 
   # Reports
   @callback create_latest_report(Config.t(), id, query) :: response

--- a/lib/wise_homex/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl.ex
@@ -292,27 +292,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/devices/import", payload)
   end
 
-  # Radiator
-
-  def get_radiator(config, id, query \\ %{}) do
-    Request.get(config, "/radiators/#{id}", query)
-  end
-
-  def get_radiators(config, query \\ %{}) do
-    Request.get(config, "/radiators", query)
-  end
-
-  def import_radiators(config, attrs) do
-    payload = %{
-      data: %{
-        type: "radiator-imports",
-        attributes: attrs
-      }
-    }
-
-    Request.post(config, "/radiators/import", payload)
-  end
-
   # Email Settings
 
   def update_account_email_settings(config, account_id, id, attrs) do
@@ -680,6 +659,33 @@ defmodule WiseHomex.ApiClientImpl do
     config
     |> Map.update!(:timeout, fn _ -> 30_000 end)
     |> Request.post("/property-syncs/unik", params)
+  end
+
+  # Radiator
+
+  def get_radiator(config, id, query \\ %{}) do
+    Request.get(config, "/radiators/#{id}", query)
+  end
+
+  def get_radiators(config, query \\ %{}) do
+    Request.get(config, "/radiators", query)
+  end
+
+  def import_radiators(config, attrs) do
+    payload = %{
+      data: %{
+        type: "radiator-imports",
+        attributes: attrs
+      }
+    }
+
+    Request.post(config, "/radiators/import", payload)
+  end
+
+  # Radiator Info
+
+  def get_radiator_info(config, id) do
+    Request.get(config, "/radiator-infos/#{id}")
   end
 
   # Reports

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -32,6 +32,7 @@ defmodule WiseHomex.JSONParser do
     "pongs" => WiseHomex.Pong,
     "properties" => WiseHomex.Property,
     "radiator-import-results" => WiseHomex.RadiatorImportResult,
+    "radiator-infos" => WiseHomex.RadiatorInfo,
     "radiators" => WiseHomex.Radiator,
     "rooms" => WiseHomex.Room,
     "settlement-keys" => WiseHomex.SettlementKey,

--- a/lib/wise_homex/models/radiator.ex
+++ b/lib/wise_homex/models/radiator.ex
@@ -8,20 +8,21 @@ defmodule WiseHomex.Radiator do
   embedded_schema do
     has_many :heat_sources, WiseHomex.HeatSource
 
-    field :internal_id, :integer
-    field :group, :string
-    field :group_id, :integer
-    field :manufacturer, :string
-    field :model, :string
-    field :illustration_number, :integer
-    field :surface_type, :string
-    field :radiator_type, :string
+    field :alt_height, :integer
+    field :archived_at, :utc_datetime
     field :columns, :integer
     field :depth, :integer
-    field :height, :integer
-    field :alt_height, :integer
     field :element_length, :integer
+    field :group, :string
+    field :group_id, :integer
+    field :height, :integer
+    field :info, :string
+    field :illustration_number, :integer
+    field :internal_id, :integer
+    field :manufacturer, :string
+    field :model, :string
     field :performance_per_element, :float
-    field :archived_at, :utc_datetime
+    field :radiator_type, :string
+    field :surface_type, :string
   end
 end

--- a/lib/wise_homex/models/radiator_info.ex
+++ b/lib/wise_homex/models/radiator_info.ex
@@ -1,0 +1,9 @@
+defmodule WiseHomex.RadiatorInfo do
+  @moduledoc false
+
+  use WiseHomex.BaseModel
+
+  embedded_schema do
+    field :pdf_url, :string
+  end
+end

--- a/lib/wise_homex/test/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock.ex
@@ -148,19 +148,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:import_devices, %{attrs: attrs, rels: rels})
   end
 
-  # Radiator
-  def get_radiator(_config, id, query \\ %{}) do
-    call_and_get_mock_value(:get_radiator, %{id: id, query: query})
-  end
-
-  def get_radiators(_config, query \\ %{}) do
-    call_and_get_mock_value(:get_radiators, %{query: query})
-  end
-
-  def import_radiators(_config, attrs) do
-    call_and_get_mock_value(:import_radiators, %{attrs: attrs})
-  end
-
   # Email Settings
   def update_account_email_settings(_config, account_id, id, attrs) do
     call_and_get_mock_value(:update_account_email_settings, %{
@@ -324,6 +311,24 @@ defmodule WiseHomex.Test.ApiClientMock do
       company_number: company_number,
       admin_id: admin_id
     })
+  end
+
+  # Radiator
+  def get_radiator(_config, id, query \\ %{}) do
+    call_and_get_mock_value(:get_radiator, %{id: id, query: query})
+  end
+
+  def get_radiators(_config, query \\ %{}) do
+    call_and_get_mock_value(:get_radiators, %{query: query})
+  end
+
+  def import_radiators(_config, attrs) do
+    call_and_get_mock_value(:import_radiators, %{attrs: attrs})
+  end
+
+  # Radiator Info
+  def get_radiator_info(_config, id) do
+    call_and_get_mock_value(:get_radiator_info, %{id: id})
   end
 
   # Reports


### PR DESCRIPTION
Fixes #104 

- Adds `:info` string field to Radiator model, sorts model fields
- Rearranges the Radiator-section in all api_client files to match the alphabetical sorting
- Adds support for the `radiator-info` endpoint