### PR TITLE
Add support for query on :create and :update

### DIFF
--- a/lib/creator.ex
+++ b/lib/creator.ex
@@ -44,7 +44,7 @@ defmodule WiseHomex.Creator do
 
     quote do
       def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}),
-        do: api_client().unquote(function_name)(config, attrs, rels)
+        do: api_client().unquote(function_name)(config, attrs, rels, query)
     end
   end
 
@@ -56,7 +56,7 @@ defmodule WiseHomex.Creator do
 
     quote do
       def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}),
-        do: api_client().unquote(function_name)(config, id, attrs, rels)
+        do: api_client().unquote(function_name)(config, id, attrs, rels, query)
     end
   end
 

--- a/lib/creator.ex
+++ b/lib/creator.ex
@@ -43,7 +43,7 @@ defmodule WiseHomex.Creator do
     function_name = "create_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, attrs, rels \\ %{}),
+      def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}),
         do: api_client().unquote(function_name)(config, attrs, rels)
     end
   end
@@ -55,7 +55,7 @@ defmodule WiseHomex.Creator do
     function_name = "update_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, attrs, rels \\ %{}),
+      def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}),
         do: api_client().unquote(function_name)(config, id, attrs, rels)
     end
   end

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -73,8 +73,8 @@ defmodule WiseHomex.ApiClientBehaviour do
   # Expense
   @callback get_expenses(Config.t(), query) :: response
   @callback get_expense(Config.t(), id, query) :: response
-  @callback create_expense(Config.t(), attributes, relationships) :: response
-  @callback update_expense(Config.t(), id, attributes, relationships) :: response
+  @callback create_expense(Config.t(), attributes, relationships, query) :: response
+  @callback update_expense(Config.t(), id, attributes, relationships, query) :: response
   @callback delete_expense(Config.t(), id) :: response
 
   # Firmware

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -702,7 +702,7 @@ defmodule WiseHomex.ApiClientImpl do
       }
     }
 
-    Request.post(config, "/reports/latest", query, payload)
+    Request.post(config, "/reports/latest", payload, query)
   end
 
   def get_device_reports(config, id) do

--- a/lib/wise_homex/api_client_impl/creator.ex
+++ b/lib/wise_homex/api_client_impl/creator.ex
@@ -45,7 +45,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "create_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, attrs, rels \\ %{}) do
+      def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}) do
         payload =
           %{
             data: %{
@@ -56,7 +56,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
           }
           |> normalize_payload()
 
-        WiseHomex.Request.post(config, unquote(api_endpoint.path), payload)
+        WiseHomex.Request.post(config, unquote(api_endpoint.path), payload, query)
       end
     end
   end
@@ -68,7 +68,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "update_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, attrs, rels \\ %{}) do
+      def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}) do
         payload =
           %{
             data: %{
@@ -81,7 +81,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
           |> normalize_payload()
 
         path = "#{unquote(api_endpoint.path)}/#{id}"
-        WiseHomex.Request.patch(config, path, payload)
+        WiseHomex.Request.patch(config, path, payload, query)
       end
     end
   end

--- a/lib/wise_homex/api_client_impl/creator.ex
+++ b/lib/wise_homex/api_client_impl/creator.ex
@@ -18,7 +18,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "get_#{api_endpoint.name_plural}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, query \\ %{}) do
+      def unquote(function_name)(config, query) do
         WiseHomex.Request.get(config, unquote(api_endpoint.path), query)
       end
     end
@@ -31,7 +31,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "get_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, query \\ %{}) do
+      def unquote(function_name)(config, id, query) do
         path = "#{unquote(api_endpoint.path)}/#{id}"
         WiseHomex.Request.get(config, path, query)
       end
@@ -45,7 +45,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "create_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}) do
+      def unquote(function_name)(config, attrs, rels, query) do
         payload =
           %{
             data: %{
@@ -68,7 +68,7 @@ defmodule WiseHomex.ApiClientImpl.Creator do
     function_name = "update_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}) do
+      def unquote(function_name)(config, id, attrs, rels, query) do
         payload =
           %{
             data: %{

--- a/lib/wise_homex/request.ex
+++ b/lib/wise_homex/request.ex
@@ -29,20 +29,23 @@ defmodule WiseHomex.Request do
     |> parse_response()
   end
 
-  def post(config, path, query, body) when is_map(query) and is_map(body) do
+  def post(config, path, body, query) when is_map(query) and is_map(body) do
     post(config, path |> path_with_query(query), body)
   end
 
-  def patch(config, path, params) do
+  def patch(config, path, body) do
     headers = build_headers(config)
-    body = Jason.encode!(params)
     options = build_options(config)
 
     path
     |> versionise_path(config)
     |> add_base_url(config)
-    |> HTTPoison.patch(body, headers, options)
+    |> HTTPoison.patch(body |> Jason.encode!(), headers, options)
     |> parse_response()
+  end
+
+  def patch(config, path, body, query) when is_map(query) and is_map(body) do
+    patch(config, path |> path_with_query(query), body)
   end
 
   def delete(config, path) do

--- a/lib/wise_homex/test/api_client_mock/creator.ex
+++ b/lib/wise_homex/test/api_client_mock/creator.ex
@@ -44,8 +44,11 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "create_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, attrs, rels \\ %{}) do
-        WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), %{attrs: attrs, rels: rels})
+      def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}) do
+        args = %{attrs: attrs, rels: rels}
+        args = if(query == %{}, do: args, else: args |> Map.put(:query, query))
+
+        WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), args)
       end
     end
   end
@@ -57,12 +60,11 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "update_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, attrs, rels \\ %{}) do
-        WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), %{
-          id: id,
-          attrs: attrs,
-          rels: rels
-        })
+      def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}) do
+        args = %{id: id, attrs: attrs, rels: rels}
+        args = if(query == %{}, do: args, else: args |> Map.put(:query, query))
+
+        WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), args)
       end
     end
   end

--- a/lib/wise_homex/test/api_client_mock/creator.ex
+++ b/lib/wise_homex/test/api_client_mock/creator.ex
@@ -45,8 +45,10 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
 
     quote do
       def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}) do
-        args = %{attrs: attrs, rels: rels}
-        args = if(query == %{}, do: args, else: args |> Map.put(:query, query))
+        args =
+          [attrs: attrs, rels: rels, query: query]
+          |> Enum.reject(fn {_key, value} -> value == %{} end)
+          |> Enum.into(%{})
 
         WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), args)
       end
@@ -61,8 +63,10 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
 
     quote do
       def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}) do
-        args = %{id: id, attrs: attrs, rels: rels}
-        args = if(query == %{}, do: args, else: args |> Map.put(:query, query))
+        args =
+          [id: id, attrs: attrs, rels: rels, query: query]
+          |> Enum.reject(fn {_key, value} -> value == %{} end)
+          |> Enum.into(%{})
 
         WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), args)
       end

--- a/lib/wise_homex/test/api_client_mock/creator.ex
+++ b/lib/wise_homex/test/api_client_mock/creator.ex
@@ -18,7 +18,7 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "get_#{api_endpoint.name_plural}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, query \\ %{}) do
+      def unquote(function_name)(config, query) do
         WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), %{query: query})
       end
     end
@@ -31,7 +31,7 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "get_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, query \\ %{}) do
+      def unquote(function_name)(config, id, query) do
         WiseHomex.Test.ApiClientMockServer.call_and_get_mock_value(unquote(function_name), %{id: id, query: query})
       end
     end
@@ -44,7 +44,7 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "create_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, attrs, rels \\ %{}, query \\ %{}) do
+      def unquote(function_name)(config, attrs, rels, query) do
         args =
           [attrs: attrs, rels: rels, query: query]
           |> Enum.reject(fn {_key, value} -> value == %{} end)
@@ -62,7 +62,7 @@ defmodule WiseHomex.Test.ApiClientMock.Creator do
     function_name = "update_#{api_endpoint.name_singular}" |> String.to_atom()
 
     quote do
-      def unquote(function_name)(config, id, attrs, rels \\ %{}, query \\ %{}) do
+      def unquote(function_name)(config, id, attrs, rels, query) do
         args =
           [id: id, attrs: attrs, rels: rels, query: query]
           |> Enum.reject(fn {_key, value} -> value == %{} end)


### PR DESCRIPTION
Fixes #118 

- Adds support for `query` on `:create` and `:update`
- Removes empty `query`, `attrs` and `rels` attributes from the mock server calls for autogenerated functions
- Cleans up a the `Request.post/4` function to make it match the parameter order of `Request.post/3`, the change should not have any effects

Note that this PR is backwards incompatible for tests for `Expense` resources, because the api mock changes for autogenerated api functions. The breaking change is that empty maps are removed from the mock call arguments.