### PR TITLE
Generate Account, AccountUser, Address, AdminIntegration, AdminIntegrationUnik endpoints automatically

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,20 +91,6 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
-  # Admin Integration UNIK
-
-  @doc """
-  Create a UNIK admin integration
-  """
-  def create_admin_integration_unik(config, attrs, rels),
-    do: api_client().create_admin_integration_unik(config, attrs, rels)
-
-  @doc """
-  Update a UNIK admin integration
-  """
-  def update_admin_integration_unik(config, id, attrs),
-    do: api_client().update_admin_integration_unik(config, id, attrs)
-
   # Angel Note
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,27 +91,6 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
-  # Account User
-
-  @doc """
-  Gets the account users for the current user.
-
-  * Optional includes: `user`, `account`
-  * Optional filters: `role`, `account_id`
-
-  Example:
-
-  ```
-  config |> WiseHomex.get_account_users(%{"include" => "user", "filter[role]" => "tenant"})
-  ```
-  """
-  def get_account_users(config, query \\ %{}), do: api_client().get_account_users(config, query)
-
-  @doc """
-  Delete an account_user
-  """
-  def delete_account_user(config, id), do: api_client().delete_account_user(config, id)
-
   # Address
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,23 +91,6 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
-  # Admin Integration
-
-  @doc """
-  Get admin integrations
-  """
-  def get_admin_integrations(config, query \\ %{}), do: api_client().get_admin_integrations(config, query)
-
-  @doc """
-  Get admin integration
-  """
-  def get_admin_integration(config, id, query \\ %{}), do: api_client().get_admin_integration(config, id, query)
-
-  @doc """
-  Delete an admin integration
-  """
-  def delete_admin_integration(config, id), do: api_client().delete_admin_integration(config, id)
-
   # Admin Integration UNIK
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,28 +91,6 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
-  # Address
-
-  @doc """
-  Create an address
-  """
-  def create_address(config, attrs, rels), do: api_client().create_address(config, attrs, rels)
-
-  @doc """
-  Update an address
-  """
-  def update_address(config, id, attrs), do: api_client().update_address(config, id, attrs)
-
-  @doc """
-  Get an address
-  """
-  def get_address(config, id, query \\ %{}), do: api_client().get_address(config, id, query)
-
-  @doc """
-  List addresses
-  """
-  def get_addresses(config, query \\ %{}), do: api_client().get_addresses(config, query)
-
   # Admin Integration
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,33 +91,6 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
-  # Account
-
-  @doc """
-  Create an account
-  """
-  def create_account(config, attributes, rels), do: api_client().create_account(config, attributes, rels)
-
-  @doc """
-  Delete an account
-  """
-  def delete_account(config, id), do: api_client().delete_account(config, id)
-
-  @doc """
-  Get an account
-  """
-  def get_account(config, id, query \\ %{}), do: api_client().get_account(config, id, query)
-
-  @doc """
-  Get multiple accounts
-  """
-  def get_accounts(config, query \\ %{}), do: api_client().get_accounts(config, query)
-
-  @doc """
-  Update an account
-  """
-  def update_account(config, id, attrs), do: api_client().update_account(config, id, attrs)
-
   # Account User
 
   @doc """

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -15,11 +15,11 @@ defmodule WiseHomex.ApiClientBehaviour do
   @type relationships :: map
 
   # Account
-  @callback create_account(Config.t(), attributes, relationships) :: response
+  @callback create_account(Config.t(), attributes, relationships, query) :: response
   @callback delete_account(Config.t(), id) :: response
   @callback get_account(Config.t(), id, query) :: response
   @callback get_accounts(Config.t(), query) :: response
-  @callback update_account(Config.t(), id, attributes) :: response
+  @callback update_account(Config.t(), id, attributes, relationships, query) :: response
 
   # Account User
   @callback get_account_users(Config.t(), query) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -37,8 +37,8 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback get_admin_integrations(Config.t(), query) :: response
 
   # Admin Integration UNIK
-  @callback create_admin_integration_unik(Config.t(), attributes, relationships) :: response
-  @callback update_admin_integration_unik(Config.t(), id, attributes) :: response
+  @callback create_admin_integration_unik(Config.t(), attributes, relationships, query) :: response
+  @callback update_admin_integration_unik(Config.t(), id, attributes, relationships, query) :: response
 
   # Angel Note
   @callback create_angel_note(Config.t(), attributes) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -26,8 +26,8 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback delete_account_user(Config.t(), id) :: response
 
   # Address
-  @callback create_address(Config.t(), attributes, relationships) :: response
-  @callback update_address(Config.t(), id, attributes) :: response
+  @callback create_address(Config.t(), attributes, relationships, query) :: response
+  @callback update_address(Config.t(), id, attributes, relationships, query) :: response
   @callback get_address(Config.t(), id, query) :: response
   @callback get_addresses(Config.t(), query) :: response
 

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,15 +13,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
-  # Account User
-  def get_account_users(config, query) do
-    Request.get(config, "/account-users", query)
-  end
-
-  def delete_account_user(config, id) do
-    Request.delete(config, "/account-users/#{id}")
-  end
-
   # Address
   def create_address(config, attrs, rels) do
     params =

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,43 +13,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
-  # Address
-  def create_address(config, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "addresses",
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/addresses", params)
-  end
-
-  def update_address(config, id, attrs) do
-    params =
-      %{
-        data: %{
-          type: "addresses",
-          id: id,
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/addresses/#{id}", params)
-  end
-
-  def get_address(config, id, query \\ %{}) do
-    Request.get(config, "/addresses/" <> id, query)
-  end
-
-  def get_addresses(config, query \\ %{}) do
-    Request.get(config, "/addresses", query)
-  end
-
   # Admin integration
   def delete_admin_integration(config, id) do
     Request.delete(config, "/admin-integrations/" <> id)

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,35 +13,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
-  # Admin integration UNIK
-  def create_admin_integration_unik(config, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "admin-integrations",
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/admin-integrations/unik", params)
-  end
-
-  def update_admin_integration_unik(config, id, attrs) do
-    params =
-      %{
-        data: %{
-          type: "admin-integrations",
-          id: id,
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/admin-integrations/unik/" <> id, params)
-  end
-
   # Angel Note
   def create_angel_note(config, attrs) do
     payload =

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,19 +13,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
-  # Admin integration
-  def delete_admin_integration(config, id) do
-    Request.delete(config, "/admin-integrations/" <> id)
-  end
-
-  def get_admin_integrations(config, query \\ %{}) do
-    Request.get(config, "/admin-integrations", query)
-  end
-
-  def get_admin_integration(config, id, query \\ %{}) do
-    Request.get(config, "/admin-integrations/" <> id, query)
-  end
-
   # Admin integration UNIK
   def create_admin_integration_unik(config, attrs, rels) do
     params =

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,49 +13,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
-  # Account
-  def create_account(config, attributes, rels) do
-    Map.put_new(attributes, :owner_id, nil)
-
-    params =
-      %{
-        data: %{
-          type: "accounts",
-          attributes: attributes,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/accounts", params)
-  end
-
-  def delete_account(config, id) do
-    Request.delete(config, "/accounts/" <> id)
-  end
-
-  def get_account(config, id, query \\ %{}) do
-    Request.get(config, "/accounts/" <> id, query)
-  end
-
-  def get_accounts(config, query \\ %{}) do
-    Request.get(config, "/accounts", query)
-  end
-
-  def update_account(config, id, attrs) do
-    payload =
-      %{
-        data: %{
-          type: "accounts",
-          id: id,
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/accounts/" <> id, payload)
-  end
-
   # Account User
   def get_account_users(config, query) do
     Request.get(config, "/account-users", query)

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -10,6 +10,14 @@ endpoints = [
     type: "accounts"
   },
   %{
+    endpoints: [:index, :delete],
+    model: WiseHomex.AccountUser,
+    name_plural: "account_users",
+    name_singular: "account_user",
+    path: "/account-users",
+    type: "account-users"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -18,6 +18,14 @@ endpoints = [
     type: "account-users"
   },
   %{
+    endpoints: [:index, :show, :create, :update],
+    model: WiseHomex.Address,
+    name_plural: "addresses",
+    name_singular: "address",
+    path: "/addresses",
+    type: "addresses"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -3,6 +3,14 @@
 endpoints = [
   %{
     endpoints: [:index, :show, :create, :update, :delete],
+    model: WiseHomex.Account,
+    name_plural: "accounts",
+    name_singular: "account",
+    path: "/accounts",
+    type: "accounts"
+  },
+  %{
+    endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",
     name_singular: "expense",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -26,6 +26,14 @@ endpoints = [
     type: "addresses"
   },
   %{
+    endpoints: [:index, :show, :delete],
+    model: WiseHomex.AdminIntegration,
+    name_plural: "admin_integrations",
+    name_singular: "admin_integration",
+    path: "/admin-integrations",
+    type: "admin-integrations"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -34,6 +34,14 @@ endpoints = [
     type: "admin-integrations"
   },
   %{
+    endpoints: [:create, :update],
+    model: WiseHomex.AdminIntegration,
+    name_plural: "admin_integrations_unik",
+    name_singular: "admin_integration_unik",
+    path: "/admin-integrations/unik",
+    type: "admin-integrations"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/api_definition.ex
+++ b/lib/wise_homex/api_definition.ex
@@ -20,6 +20,7 @@ defmodule WiseHomex.ApiDefinition do
     """
     @type resource_definition :: %{
             endpoints: [verb],
+            model: atom(),
             name_plural: String.t(),
             name_singular: String.t(),
             path: String.t(),

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -7,7 +7,6 @@ defmodule WiseHomex.JSONParser do
 
   @structs %{
              "account-email-settings" => WiseHomex.Account.EmailSettings,
-             "admin-integrations" => WiseHomex.AdminIntegration,
              "angel-notes" => WiseHomex.AngelNote,
              "configurable-meter-id" => WiseHomex.ConfigurableMeterID,
              "configurable-meters" => WiseHomex.ConfigurableMeters,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -8,7 +8,6 @@ defmodule WiseHomex.JSONParser do
   @structs %{
              "account-email-settings" => WiseHomex.Account.EmailSettings,
              "account-users" => WiseHomex.AccountUser,
-             "accounts" => WiseHomex.Account,
              "addresses" => WiseHomex.Address,
              "admin-integrations" => WiseHomex.AdminIntegration,
              "angel-notes" => WiseHomex.AngelNote,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -7,7 +7,6 @@ defmodule WiseHomex.JSONParser do
 
   @structs %{
              "account-email-settings" => WiseHomex.Account.EmailSettings,
-             "account-users" => WiseHomex.AccountUser,
              "addresses" => WiseHomex.Address,
              "admin-integrations" => WiseHomex.AdminIntegration,
              "angel-notes" => WiseHomex.AngelNote,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -7,7 +7,6 @@ defmodule WiseHomex.JSONParser do
 
   @structs %{
              "account-email-settings" => WiseHomex.Account.EmailSettings,
-             "addresses" => WiseHomex.Address,
              "admin-integrations" => WiseHomex.AdminIntegration,
              "angel-notes" => WiseHomex.AngelNote,
              "configurable-meter-id" => WiseHomex.ConfigurableMeterID,

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,15 +10,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
-  # Account User
-  def get_account_users(_config, query) do
-    call_and_get_mock_value(:get_account_users, %{query: query})
-  end
-
-  def delete_account_user(_config, id) do
-    call_and_get_mock_value(:delete_account_user, %{id: id})
-  end
-
   # Address
   def create_address(_config, attrs, rels) do
     call_and_get_mock_value(:create_address, %{attrs: attrs, rels: rels})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,19 +10,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
-  # Admin Integration
-  def get_admin_integrations(_config, query \\ %{}) do
-    call_and_get_mock_value(:get_admin_integrations, %{query: query})
-  end
-
-  def get_admin_integration(_config, id, query \\ %{}) do
-    call_and_get_mock_value(:get_admin_integration, %{id: id, query: query})
-  end
-
-  def delete_admin_integration(_config, id) do
-    call_and_get_mock_value(:delete_admin_integration, %{id: id})
-  end
-
   # Admin Integration UNIK
   def create_admin_integration_unik(_config, attrs, rels) do
     call_and_get_mock_value(:create_admin_integration_unik, %{attrs: attrs, rels: rels})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,27 +10,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
-  # Account
-  def create_account(_config, attrs, rels) do
-    call_and_get_mock_value(:create_account, %{attrs: attrs, rels: rels})
-  end
-
-  def delete_account(_config, id) do
-    call_and_get_mock_value(:delete_account, %{id: id})
-  end
-
-  def get_account(_config, id, query) do
-    call_and_get_mock_value(:get_account, %{id: id, query: query})
-  end
-
-  def get_accounts(_config, query) do
-    call_and_get_mock_value(:get_accounts, %{query: query})
-  end
-
-  def update_account(_config, id, attrs) do
-    call_and_get_mock_value(:update_account, %{id: id, attrs: attrs})
-  end
-
   # Account User
   def get_account_users(_config, query) do
     call_and_get_mock_value(:get_account_users, %{query: query})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,15 +10,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
-  # Admin Integration UNIK
-  def create_admin_integration_unik(_config, attrs, rels) do
-    call_and_get_mock_value(:create_admin_integration_unik, %{attrs: attrs, rels: rels})
-  end
-
-  def update_admin_integration_unik(_config, id, attrs) do
-    call_and_get_mock_value(:update_admin_integration_unik, %{id: id, attrs: attrs})
-  end
-
   # Angel Note
   def get_angel_note(_config, target_type, target_id) do
     call_and_get_mock_value(:get_angel_note, %{target_type: target_type, target_id: target_id})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,23 +10,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
-  # Address
-  def create_address(_config, attrs, rels) do
-    call_and_get_mock_value(:create_address, %{attrs: attrs, rels: rels})
-  end
-
-  def update_address(_config, id, attrs) do
-    call_and_get_mock_value(:update_address, %{id: id, attrs: attrs})
-  end
-
-  def get_address(_config, id, query) do
-    call_and_get_mock_value(:get_address, %{id: id, query: query})
-  end
-
-  def get_addresses(_config, query \\ %{}) do
-    call_and_get_mock_value(:get_addresses, %{query: query})
-  end
-
   # Admin Integration
   def get_admin_integrations(_config, query \\ %{}) do
     call_and_get_mock_value(:get_admin_integrations, %{query: query})

--- a/test/api_definition_test.exs
+++ b/test/api_definition_test.exs
@@ -3,4 +3,40 @@ defmodule WiseHomex.ApiDefinitionTest do
 
   alias WiseHomex.ApiDefinition
   doctest ApiDefinition
+
+  describe "type_to_model_mappings" do
+    test "produces expected output" do
+      api_config = [
+        %{type: "accounts", model: WiseHomex.Account},
+        %{type: "account-users", model: WiseHomex.AccountUser},
+        %{type: "admin-integrations", model: WiseHomex.AdminIntegration}
+      ]
+
+      assert WiseHomex.ApiDefinition.Reader.type_to_model_mappings(api_config) == %{
+               "accounts" => WiseHomex.Account,
+               "account-users" => WiseHomex.AccountUser,
+               "admin-integrations" => WiseHomex.AdminIntegration
+             }
+    end
+
+    test "does not raise if defining two identical types with identical model" do
+      api_config = [
+        %{type: "accounts", model: WiseHomex.Account},
+        %{type: "accounts", model: WiseHomex.Account}
+      ]
+
+      assert WiseHomex.ApiDefinition.Reader.type_to_model_mappings(api_config) == %{"accounts" => WiseHomex.Account}
+    end
+
+    test "raises if defining two identical types with different models" do
+      api_config = [
+        %{type: "accounts", model: WiseHomex.AccountUser},
+        %{type: "accounts", model: WiseHomex.Account}
+      ]
+
+      assert_raise(ArgumentError, ~s[Multiple models defined for type "accounts"], fn ->
+        WiseHomex.ApiDefinition.Reader.type_to_model_mappings(api_config)
+      end)
+    end
+  end
 end


### PR DESCRIPTION
Ref: #125 

Creates functions for these endpoints automatically: 
- [x] `Account`
- [x] `AccountUser`
- [x] `Address`
- [x] `AdminIntegration`
- [x] `AdminIntegrationUnik`

Everything should be good to go, but test it in practice just to be sure.