### PR TITLE
125 2 automatic endpoints

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -152,23 +152,6 @@ defmodule WiseHomex do
   def update_account_email_settings(config, account_id, id, attrs),
     do: api_client().update_account_email_settings(config, account_id, id, attrs)
 
-  # External Info
-
-  @doc """
-  Create ExternalInfo
-  """
-  def create_external_info(config, attrs, rels), do: api_client().create_external_info(config, attrs, rels)
-
-  @doc """
-  Update ExternalInfo
-  """
-  def update_external_info(config, id, attrs), do: api_client().update_external_info(config, id, attrs)
-
-  @doc """
-  Delete ExternalInfo
-  """
-  def delete_external_info(config, id), do: api_client().delete_external_info(config, id)
-
   # Firmware
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -124,24 +124,9 @@ defmodule WiseHomex do
   def deauthorize_device(config, device_id), do: api_client().deauthorize_device(config, device_id)
 
   @doc """
-  Delete a device
-  """
-  def delete_device(config, id), do: api_client().delete_device(config, id)
-
-  @doc """
   Fast ping a device
   """
   def fast_ping_device(config, id), do: api_client().fast_ping_device(config, id)
-
-  @doc """
-  Get a device
-  """
-  def get_device(config, id, query \\ %{}), do: api_client().get_device(config, id, query)
-
-  @doc """
-  Get multiple devices
-  """
-  def get_devices(config, query \\ %{}), do: api_client().get_devices(config, query)
 
   @doc """
   Set device location
@@ -153,11 +138,6 @@ defmodule WiseHomex do
   Unset device location
   """
   def unset_device_location(config, device_id), do: api_client().unset_device_location(config, device_id)
-
-  @doc """
-  Update a device
-  """
-  def update_device(config, id, attrs, rels), do: api_client().update_device(config, id, attrs, rels)
 
   @doc """
   Import devices from CSV

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -159,16 +159,6 @@ defmodule WiseHomex do
   """
   def create_firmware(config, file_content), do: api_client().create_firmware(config, file_content)
 
-  @doc """
-  Delete firmware
-  """
-  def delete_firmware(config, id), do: api_client().delete_firmware(config, id)
-
-  @doc """
-  Get firmwares
-  """
-  def get_firmwares(config), do: api_client().get_firmwares(config)
-
   # Fiscal Year
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -159,33 +159,6 @@ defmodule WiseHomex do
   """
   def create_firmware(config, file_content), do: api_client().create_firmware(config, file_content)
 
-  # Fiscal Year
-
-  @doc """
-  Get multiple fiscal years
-  """
-  def get_fiscal_years(config, query \\ %{}), do: api_client().get_fiscal_years(config, query)
-
-  @doc """
-  Get a single fiscal year
-  """
-  def get_fiscal_year(config, id, query \\ %{}), do: api_client().get_fiscal_year(config, id, query)
-
-  @doc """
-  Create a fiscal year
-  """
-  def create_fiscal_year(config, attrs, rels), do: api_client().create_fiscal_year(config, attrs, rels)
-
-  @doc """
-  Update a fiscal year
-  """
-  def update_fiscal_year(config, id, attrs, rels), do: api_client().update_fiscal_year(config, id, attrs, rels)
-
-  @doc """
-  Delete a fiscal year
-  """
-  def delete_fiscal_year(config, id), do: api_client().delete_fiscal_year(config, id)
-
   # Gateway
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -98,25 +98,6 @@ defmodule WiseHomex do
   """
   def get_angel_note(config, target_type, target_id), do: api_client().get_angel_note(config, target_type, target_id)
 
-  @doc """
-  Create an angel note
-
-  * Required attributes: `target_type`, `target_id`, `content`
-  """
-  def create_angel_note(config, attrs), do: api_client().create_angel_note(config, attrs)
-
-  @doc """
-  Update an angel note
-
-  * Only the `content` attribute can be changed
-  """
-  def update_angel_note(config, id, attrs), do: api_client().update_angel_note(config, id, attrs)
-
-  @doc """
-  Delete an angel note by its id
-  """
-  def delete_angel_note(config, id), do: api_client().delete_angel_note(config, id)
-
   # Bmeters Keys
 
   @doc """

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -85,8 +85,8 @@ defmodule WiseHomex.ApiClientBehaviour do
   # Fiscal Years
   @callback get_fiscal_years(Config.t(), query) :: response
   @callback get_fiscal_year(Config.t(), id, query) :: response
-  @callback create_fiscal_year(Config.t(), attributes, relationships) :: response
-  @callback update_fiscal_year(Config.t(), id, attributes, relationships) :: response
+  @callback create_fiscal_year(Config.t(), attributes, relationships, query) :: response
+  @callback update_fiscal_year(Config.t(), id, attributes, relationships, query) :: response
   @callback delete_fiscal_year(Config.t(), id) :: response
 
   # Gateway

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -66,9 +66,9 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback update_account_email_settings(Config.t(), id, id, attributes) :: response
 
   # External Info
-  @callback create_external_info(Config.t(), attributes, relationships) :: response
+  @callback create_external_info(Config.t(), attributes, relationships, query) :: response
   @callback delete_external_info(Config.t(), id) :: response
-  @callback update_external_info(Config.t(), id, attributes) :: response
+  @callback update_external_info(Config.t(), id, attributes, relationships, query) :: response
 
   # Expense
   @callback get_expenses(Config.t(), query) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -80,7 +80,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   # Firmware
   @callback create_firmware(Config.t(), String.t()) :: response
   @callback delete_firmware(Config.t(), id) :: response
-  @callback get_firmwares(Config.t()) :: response
+  @callback get_firmwares(Config.t(), query) :: response
 
   # Fiscal Years
   @callback get_fiscal_years(Config.t(), query) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -59,7 +59,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback get_devices(Config.t(), query) :: response
   @callback set_device_location(Config.t(), id, attributes, relationships) :: response
   @callback unset_device_location(Config.t(), id) :: response
-  @callback update_device(Config.t(), id, attributes, relationships) :: response
+  @callback update_device(Config.t(), id, attributes, relationships, query) :: response
   @callback import_devices(Config.t(), attributes, relationships) :: response
 
   # Email Settings

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -41,10 +41,10 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback update_admin_integration_unik(Config.t(), id, attributes, relationships, query) :: response
 
   # Angel Note
-  @callback create_angel_note(Config.t(), attributes) :: response
+  @callback create_angel_note(Config.t(), attributes, relationships, query) :: response
   @callback delete_angel_note(Config.t(), id) :: response
   @callback get_angel_note(Config.t(), String.t(), id) :: response
-  @callback update_angel_note(Config.t(), id, attributes) :: response
+  @callback update_angel_note(Config.t(), id, attributes, relationships, query) :: response
 
   # Bmeters Keys
   @callback upload_bmeters_keys(Config.t(), list) :: response

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -135,14 +135,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/firmwares", payload)
   end
 
-  def delete_firmware(config, id) do
-    Request.delete(config, "/firmwares/" <> id)
-  end
-
-  def get_firmwares(config) do
-    Request.get(config, "/firmwares", %{"page[size]" => 500})
-  end
-
   # Fiscal Year
 
   def get_fiscal_years(config, query \\ %{}) do

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -14,39 +14,8 @@ defmodule WiseHomex.ApiClientImpl do
   use WiseHomex.ApiClientImpl.Creator
 
   # Angel Note
-  def create_angel_note(config, attrs) do
-    payload =
-      %{
-        data: %{
-          type: "angel-notes",
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/angel-notes", payload)
-  end
-
-  def delete_angel_note(config, id) do
-    Request.delete(config, "/angel-notes/" <> id)
-  end
-
   def get_angel_note(config, target_type, target_id) do
     Request.get(config, "/angel-notes/#{target_type}/#{target_id}")
-  end
-
-  def update_angel_note(config, id, attrs) do
-    payload =
-      %{
-        data: %{
-          type: "angel-notes",
-          id: id,
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/angel-notes/" <> id, payload)
   end
 
   # Bmeters Keys

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -62,10 +62,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.delete(config, "/devices/" <> device_id <> "/authorizations")
   end
 
-  def delete_device(config, id) do
-    Request.delete(config, "/devices/" <> id)
-  end
-
   def fast_ping_device(config, id) do
     params =
       %{
@@ -76,14 +72,6 @@ defmodule WiseHomex.ApiClientImpl do
       |> normalize_payload
 
     Request.post(config, "/devices/" <> id <> "/fast-pings", params)
-  end
-
-  def get_device(config, id, query \\ %{}) do
-    Request.get(config, "/devices/" <> id, query)
-  end
-
-  def get_devices(config, query \\ %{}) do
-    Request.get(config, "/devices", query)
   end
 
   def set_device_location(config, device_id, attrs, rels) do
@@ -102,21 +90,6 @@ defmodule WiseHomex.ApiClientImpl do
 
   def unset_device_location(config, device_id) do
     Request.delete(config, "/devices/#{device_id}/location")
-  end
-
-  def update_device(config, id, attrs, rels) do
-    payload =
-      %{
-        data: %{
-          type: "devices",
-          id: id,
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload()
-
-    Request.patch(config, "/devices/#{id}", payload)
   end
 
   def import_devices(config, attrs, rels) do

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -135,49 +135,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/firmwares", payload)
   end
 
-  # Fiscal Year
-
-  def get_fiscal_years(config, query \\ %{}) do
-    Request.get(config, "/fiscal-years", query)
-  end
-
-  def get_fiscal_year(config, id, query \\ %{}) do
-    Request.get(config, "/fiscal-years/#{id}", query)
-  end
-
-  def create_fiscal_year(config, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "fiscal-years",
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload()
-
-    Request.post(config, "/fiscal-years", params)
-  end
-
-  def update_fiscal_year(config, id, attrs, rels) do
-    payload =
-      %{
-        data: %{
-          type: "fiscal-years",
-          id: id,
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload()
-
-    Request.patch(config, "/fiscal-years/#{id}", payload)
-  end
-
-  def delete_fiscal_year(config, id) do
-    Request.delete(config, "/fiscal-years/#{id}")
-  end
-
   # Gateway
   def get_gateway(config, id, query \\ %{}) do
     Request.get(config, "/gateways/" <> id, query)

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -120,40 +120,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.patch(config, "/accounts/" <> account_id <> "/email-settings", payload)
   end
 
-  # External Info
-
-  def create_external_info(config, attributes, relationships) do
-    payload =
-      %{
-        data: %{
-          type: "external-infos",
-          attributes: attributes,
-          relationships: relationships
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/external-infos", payload)
-  end
-
-  def delete_external_info(config, id) do
-    Request.delete(config, "/external-infos/" <> id)
-  end
-
-  def update_external_info(config, id, attributes) do
-    payload =
-      %{
-        data: %{
-          type: "external-infos",
-          id: id,
-          attributes: attributes
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/external-infos/" <> id, payload)
-  end
-
   # Firmware
 
   def create_firmware(config, file_content) do

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -50,6 +50,14 @@ endpoints = [
     type: "angel-notes"
   },
   %{
+    endpoints: [:index, :show, :update, :delete],
+    model: WiseHomex.Device,
+    name_plural: "devices",
+    name_singular: "device",
+    path: "/devices",
+    type: "devices"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -82,6 +82,14 @@ endpoints = [
     type: "firmwares"
   },
   %{
+    endpoints: [:index, :show, :create, :update, :delete],
+    model: WiseHomex.FiscalYear,
+    name_plural: "fiscal_years",
+    name_singular: "fiscal_year",
+    path: "/fiscal-years",
+    type: "fiscal-years"
+  },
+  %{
     endpoints: [:create],
     model: WiseHomex.WMBusMessageQuery,
     name_plural: "wmbus_message_queries",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -74,6 +74,14 @@ endpoints = [
     type: "external-infos"
   },
   %{
+    endpoints: [:index, :delete],
+    model: WiseHomex.Firmware,
+    name_plural: "firmwares",
+    name_singular: "firmware",
+    path: "/firmwares",
+    type: "firmwares"
+  },
+  %{
     endpoints: [:create],
     model: WiseHomex.WMBusMessageQuery,
     name_plural: "wmbus_message_queries",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -66,6 +66,14 @@ endpoints = [
     type: "expenses"
   },
   %{
+    endpoints: [:create, :update, :delete],
+    model: WiseHomex.ExternalInfo,
+    name_plural: "external_infos",
+    name_singular: "external_info",
+    path: "/external-infos",
+    type: "external-infos"
+  },
+  %{
     endpoints: [:create],
     model: WiseHomex.WMBusMessageQuery,
     name_plural: "wmbus_message_queries",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -42,6 +42,14 @@ endpoints = [
     type: "admin-integrations"
   },
   %{
+    endpoints: [:create, :update, :delete],
+    model: WiseHomex.AngelNote,
+    name_plural: "angel_notes",
+    name_singular: "angel_note",
+    path: "/angel-notes",
+    type: "angel-notes"
+  },
+  %{
     endpoints: [:index, :show, :create, :update, :delete],
     model: WiseHomex.Expense,
     name_plural: "expenses",

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -7,17 +7,12 @@ defmodule WiseHomex.JSONParser do
 
   @structs %{
              "account-email-settings" => WiseHomex.Account.EmailSettings,
-             "angel-notes" => WiseHomex.AngelNote,
              "configurable-meter-id" => WiseHomex.ConfigurableMeterID,
              "configurable-meters" => WiseHomex.ConfigurableMeters,
              "device-authorizations" => WiseHomex.DeviceAuthorization,
              "device-imports" => WiseHomex.DeviceImport,
              "device-types" => WiseHomex.DeviceType,
-             "devices" => WiseHomex.Device,
              "encryption-keys" => WiseHomex.EncKey,
-             "external-infos" => WiseHomex.ExternalInfo,
-             "firmwares" => WiseHomex.Firmware,
-             "fiscal-years" => WiseHomex.FiscalYear,
              "gateways" => WiseHomex.Gateway,
              "heat-sources" => WiseHomex.HeatSource,
              "households" => WiseHomex.Household,

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -67,27 +67,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:create_firmware, %{file_content: file_content})
   end
 
-  # Fiscal Year
-  def get_fiscal_years(_config, query \\ %{}) do
-    call_and_get_mock_value(:get_fiscal_years, %{query: query})
-  end
-
-  def get_fiscal_year(_config, id, query \\ %{}) do
-    call_and_get_mock_value(:get_fiscal_year, %{id: id, query: query})
-  end
-
-  def create_fiscal_year(_config, attrs, rels) do
-    call_and_get_mock_value(:create_fiscal_year, %{attrs: attrs, rels: rels})
-  end
-
-  def update_fiscal_year(_config, id, attrs, rels) do
-    call_and_get_mock_value(:update_fiscal_year, %{id: id, attrs: attrs, rels: rels})
-  end
-
-  def delete_fiscal_year(_config, id) do
-    call_and_get_mock_value(:delete_fiscal_year, %{id: id})
-  end
-
   # Gateway
   def get_gateway(_config, id, query) do
     call_and_get_mock_value(:get_gateway, %{id: id, query: query})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -67,14 +67,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:create_firmware, %{file_content: file_content})
   end
 
-  def delete_firmware(_config, id) do
-    call_and_get_mock_value(:delete_firmware, %{id: id})
-  end
-
-  def get_firmwares(_config) do
-    call_and_get_mock_value(:get_firmwares, %{})
-  end
-
   # Fiscal Year
   def get_fiscal_years(_config, query \\ %{}) do
     call_and_get_mock_value(:get_fiscal_years, %{query: query})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -15,18 +15,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:get_angel_note, %{target_type: target_type, target_id: target_id})
   end
 
-  def create_angel_note(_config, attrs) do
-    call_and_get_mock_value(:create_angel_note, %{attrs: attrs})
-  end
-
-  def update_angel_note(_config, id, attrs) do
-    call_and_get_mock_value(:update_angel_note, %{id: id, attrs: attrs})
-  end
-
-  def delete_angel_note(_config, id) do
-    call_and_get_mock_value(:delete_angel_note, %{id: id})
-  end
-
   # Bmeters Keys
   def upload_bmeters_keys(_config, opts) do
     call_and_get_mock_value(:upload_bmeters_keys, %{opts: opts})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -62,19 +62,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     })
   end
 
-  # External Info
-  def create_external_info(_config, attrs, rels) do
-    call_and_get_mock_value(:create_external_info, %{attrs: attrs, rels: rels})
-  end
-
-  def update_external_info(_config, id, attrs) do
-    call_and_get_mock_value(:update_external_info, %{id: id, attrs: attrs})
-  end
-
-  def delete_external_info(_config, id) do
-    call_and_get_mock_value(:delete_external_info, %{id: id})
-  end
-
   # Firmware
   def create_firmware(_config, file_content) do
     call_and_get_mock_value(:create_firmware, %{file_content: file_content})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -37,20 +37,8 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:deauthorize_device, %{device_id: device_id})
   end
 
-  def delete_device(_config, id) do
-    call_and_get_mock_value(:delete_device, %{id: id})
-  end
-
   def fast_ping_device(_config, id) do
     call_and_get_mock_value(:fast_ping_device, %{id: id})
-  end
-
-  def get_device(_config, id, query) do
-    call_and_get_mock_value(:get_device, %{id: id, query: query})
-  end
-
-  def get_devices(_config, query) do
-    call_and_get_mock_value(:get_devices, %{query: query})
   end
 
   def set_device_location(_config, device_id, attrs, rels) do
@@ -59,10 +47,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   def unset_device_location(_config, device_id) do
     call_and_get_mock_value(:unset_device_location, %{device_id: device_id})
-  end
-
-  def update_device(_config, id, attrs, rels) do
-    call_and_get_mock_value(:update_device, %{id: id, attrs: attrs, rels: rels})
   end
 
   def import_devices(_config, attrs, rels) do


### PR DESCRIPTION
Ref: #125 

Autocreates five additional endpoints:

- [x] AngelNote
- [x] Device
- [x] ExternalInfo
- [x] Firmware
- [x] FiscalYear

Note: There were several endpoints that were special, making them impossible to move without downstream changes. I won't do that now, but perhaps later on.

Note 2: A limit on 500 firmwares was removed.