### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,17 +10,27 @@ jobs:
       matrix:
         otp: [22.1.8.1, 22.2.8, 22.3.2]
         elixir: [1.9.4, 1.10.2]
+    env:
+      MIX_ENV: test
     steps:
       - uses: actions/checkout@v2
         name: Checkout
 
       - uses: actions/cache@v1
-        name: Cache PLT
+        name: Cache deps
+        with:
+          path: deps
+          key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
+
+      - uses: actions/cache@v1
+        name: Cache _build
         with:
           path: _build
-          key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+          key: build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
+            build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
 
       - uses: actions/setup-elixir@v1.2.0
         name: Setup elixir
@@ -29,8 +39,7 @@ jobs:
           elixir-version: ${{matrix.elixir}}
 
       - run: mix deps.get
-      - run: mix deps.compile --force
-      - run: mix compile --force
+      - run: mix compile
       - run: mix test --trace
       - run: mix credo
       - run: mix dialyzer


### PR DESCRIPTION
This speeds up CI runs by:

- Caching both `deps` and `_build`, thereby caching the compiled files and PLT for a given Elixir, Erlang and `mix.lock` version
- Not force-compiling the project, but using an ordinary `mix compile`
- Not force-compiling deps at all

Additionally CI is now run with `MIX_ENV=test`

@lasseebert Thanks for the assistance with this :+1: