### PR TITLE
Create Gateway, HeatSource, Household, Property endpoints automatically

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -91,6 +91,14 @@ defmodule WiseHomex do
   # Get the ApiClient implementation to use
   defp api_client(), do: Application.get_env(:wise_homex, :api_client_impl, WiseHomex.ApiClientImpl)
 
+  # Account invitation
+
+  @doc """
+  Create an account invitation
+  """
+  def create_account_invitation(config, account_id, attrs),
+    do: api_client().create_account_invitation(config, account_id, attrs)
+
   # Angel Note
 
   @doc """
@@ -175,14 +183,6 @@ defmodule WiseHomex do
   Unlock a gateway
   """
   def unlock_gateway(config, id, seconds), do: api_client().unlock_gateway(config, id, seconds)
-
-  # Account invitation
-
-  @doc """
-  Create an account invitation
-  """
-  def create_account_invitation(config, account_id, attrs),
-    do: api_client().create_account_invitation(config, account_id, attrs)
 
   # KEM uploads
 

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -176,18 +176,6 @@ defmodule WiseHomex do
   """
   def unlock_gateway(config, id, seconds), do: api_client().unlock_gateway(config, id, seconds)
 
-  # HeatSource
-
-  @doc """
-  Get heat source by id
-  """
-  def get_heat_source(config, id, query \\ %{}), do: api_client().get_heat_source(config, id, query)
-
-  @doc """
-  Gets heat sources
-  """
-  def get_heat_sources(config, query \\ %{}), do: api_client().get_heat_sources(config, query)
-
   # Household
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -206,33 +206,6 @@ defmodule WiseHomex do
   """
   def ping(config, query), do: api_client().ping(config, query)
 
-  # Property
-
-  @doc """
-  Create a property
-  """
-  def create_property(config, attrs, rels), do: api_client().create_property(config, attrs, rels)
-
-  @doc """
-  Delete a property
-  """
-  def delete_property(config, id), do: api_client().delete_property(config, id)
-
-  @doc """
-  Get multiple properties
-  """
-  def get_properties(config, query \\ %{}), do: api_client().get_properties(config, query)
-
-  @doc """
-  Get a property
-  """
-  def get_property(config, id, query \\ %{}), do: api_client().get_property(config, id, query)
-
-  @doc """
-  Update a property
-  """
-  def update_property(config, id, attrs, rels), do: api_client().update_property(config, id, attrs, rels)
-
   # Property Syncs
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -176,33 +176,6 @@ defmodule WiseHomex do
   """
   def unlock_gateway(config, id, seconds), do: api_client().unlock_gateway(config, id, seconds)
 
-  # Household
-
-  @doc """
-  Create a household
-  """
-  def create_household(config, attrs, rels), do: api_client().create_household(config, attrs, rels)
-
-  @doc """
-  Delete a household
-  """
-  def delete_household(config, id), do: api_client().delete_household(config, id)
-
-  @doc """
-  Get a household
-  """
-  def get_household(config, id, query \\ %{}), do: api_client().get_household(config, id, query)
-
-  @doc """
-  Get multiple households
-  """
-  def get_households(config, query \\ %{}), do: api_client().get_households(config, query)
-
-  @doc """
-  Update a household
-  """
-  def update_household(config, id, attrs, rels), do: api_client().update_household(config, id, attrs, rels)
-
   # Account invitation
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -162,23 +162,6 @@ defmodule WiseHomex do
   # Gateway
 
   @doc """
-  Get a gateway
-  """
-  def get_gateway(config, id, query \\ %{}), do: api_client().get_gateway(config, id, query)
-
-  @doc """
-  Get multiple gateways
-  """
-  def get_gateways(config, query \\ %{}), do: api_client().get_gateways(config, query)
-
-  @doc """
-  Delete a gateway
-
-  Deleting a gateway with devices will return an error.
-  """
-  def delete_gateway(config, id), do: api_client().delete_gateway(config, id)
-
-  @doc """
   Lock a gateway
   """
   def lock_gateway(config, id), do: api_client().lock_gateway(config, id)
@@ -192,11 +175,6 @@ defmodule WiseHomex do
   Unlock a gateway
   """
   def unlock_gateway(config, id, seconds), do: api_client().unlock_gateway(config, id, seconds)
-
-  @doc """
-  Update a gateway
-  """
-  def update_gateway(config, id, attrs, rels \\ %{}), do: api_client().update_gateway(config, id, attrs, rels)
 
   # HeatSource
 

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -21,6 +21,9 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback get_accounts(Config.t(), query) :: response
   @callback update_account(Config.t(), id, attributes, relationships, query) :: response
 
+  # Account invitation
+  @callback create_account_invitation(Config.t(), id, attributes) :: response
+
   # Account Payment
   @callback create_account_payment(Config.t(), attributes, relationships, query) :: response
   @callback delete_account_payment(Config.t(), id) :: response
@@ -117,9 +120,6 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback get_household(Config.t(), id, query) :: response
   @callback get_households(Config.t(), query) :: response
   @callback update_household(Config.t(), id, attributes, relationships, query) :: response
-
-  # Account invitation
-  @callback create_account_invitation(Config.t(), id, attributes) :: response
 
   # KEM uploads
   @callback upload_kem(Config.t(), list) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -128,11 +128,11 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback ping(Config.t(), query) :: response
 
   # Property
-  @callback create_property(Config.t(), attributes, relationships) :: response
+  @callback create_property(Config.t(), attributes, relationships, query) :: response
   @callback delete_property(Config.t(), id) :: response
   @callback get_properties(Config.t(), query) :: response
   @callback get_property(Config.t(), id, query) :: response
-  @callback update_property(Config.t(), id, attributes, relationships) :: response
+  @callback update_property(Config.t(), id, attributes, relationships, query) :: response
 
   # Property Syncs
   @callback sync_property(Config.t(), id) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -105,7 +105,7 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback lock_gateway(Config.t(), id) :: response
   @callback restart_gateway(Config.t(), id) :: response
   @callback unlock_gateway(Config.t(), id, integer) :: response
-  @callback update_gateway(Config.t(), id, attributes, relationships) :: response
+  @callback update_gateway(Config.t(), id, attributes, relationships, query) :: response
 
   # HeatSource
   @callback get_heat_source(Config.t(), id, query) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -112,11 +112,11 @@ defmodule WiseHomex.ApiClientBehaviour do
   @callback get_heat_sources(Config.t(), query) :: response
 
   # Household
-  @callback create_household(Config.t(), attributes, relationships) :: response
+  @callback create_household(Config.t(), attributes, relationships, query) :: response
   @callback delete_household(Config.t(), id) :: response
   @callback get_household(Config.t(), id, query) :: response
   @callback get_households(Config.t(), query) :: response
-  @callback update_household(Config.t(), id, attributes, relationships) :: response
+  @callback update_household(Config.t(), id, attributes, relationships, query) :: response
 
   # Account invitation
   @callback create_account_invitation(Config.t(), id, attributes) :: response

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -136,18 +136,6 @@ defmodule WiseHomex.ApiClientImpl do
   end
 
   # Gateway
-  def get_gateway(config, id, query \\ %{}) do
-    Request.get(config, "/gateways/" <> id, query)
-  end
-
-  def get_gateways(config, query \\ %{}) do
-    Request.get(config, "/gateways", query)
-  end
-
-  def delete_gateway(config, id) do
-    Request.delete(config, "/gateways/" <> id)
-  end
-
   def lock_gateway(config, id) do
     payload =
       %{
@@ -185,21 +173,6 @@ defmodule WiseHomex.ApiClientImpl do
       |> normalize_payload
 
     Request.post(config, "/gateways/" <> id <> "/unlocks", payload)
-  end
-
-  def update_gateway(config, id, attrs, rels \\ %{}) do
-    payload =
-      %{
-        data: %{
-          type: "gateways",
-          id: id,
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/gateways/" <> id, payload)
   end
 
   # HeatSource

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -175,49 +175,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/gateways/" <> id <> "/unlocks", payload)
   end
 
-  # Household
-
-  def create_household(config, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "households",
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/households", params)
-  end
-
-  def delete_household(config, id) do
-    Request.delete(config, "/households/" <> id)
-  end
-
-  def get_household(config, id, query \\ %{}) do
-    Request.get(config, "/households/" <> id, query)
-  end
-
-  def get_households(config, query \\ %{}) do
-    Request.get(config, "/households", query)
-  end
-
-  def update_household(config, id, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "households",
-          id: id,
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/households/" <> id, params)
-  end
-
   # Account invitation
 
   def create_account_invitation(config, account_id, attrs) do

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -13,6 +13,20 @@ defmodule WiseHomex.ApiClientImpl do
 
   use WiseHomex.ApiClientImpl.Creator
 
+  # Account invitation
+  def create_account_invitation(config, account_id, attrs) do
+    payload =
+      %{
+        data: %{
+          type: "account-invitations",
+          attributes: attrs
+        }
+      }
+      |> normalize_payload
+
+    Request.post(config, "/accounts/" <> account_id <> "/invitations", payload)
+  end
+
   # Angel Note
   def get_angel_note(config, target_type, target_id) do
     Request.get(config, "/angel-notes/#{target_type}/#{target_id}")
@@ -173,21 +187,6 @@ defmodule WiseHomex.ApiClientImpl do
       |> normalize_payload
 
     Request.post(config, "/gateways/" <> id <> "/unlocks", payload)
-  end
-
-  # Account invitation
-
-  def create_account_invitation(config, account_id, attrs) do
-    payload =
-      %{
-        data: %{
-          type: "account-invitations",
-          attributes: attrs
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/accounts/" <> account_id <> "/invitations", payload)
   end
 
   # KEM uploads

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -216,49 +216,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.get(config, "/ping", query)
   end
 
-  # Property
-
-  def create_property(config, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "properties",
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.post(config, "/properties", params)
-  end
-
-  def delete_property(config, id) do
-    Request.delete(config, "/properties/" <> id)
-  end
-
-  def get_properties(config, query \\ %{}) do
-    Request.get(config, "/properties", query)
-  end
-
-  def get_property(config, id, query \\ %{}) do
-    Request.get(config, "/properties/" <> id, query)
-  end
-
-  def update_property(config, id, attrs, rels) do
-    params =
-      %{
-        data: %{
-          type: "properties",
-          id: id,
-          attributes: attrs,
-          relationships: rels
-        }
-      }
-      |> normalize_payload
-
-    Request.patch(config, "/properties/" <> id, params)
-  end
-
   # Property Syncs
 
   @doc """

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -175,15 +175,6 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/gateways/" <> id <> "/unlocks", payload)
   end
 
-  # HeatSource
-  def get_heat_source(config, id, query \\ %{}) do
-    Request.get(config, "/heat-sources/#{id}", query)
-  end
-
-  def get_heat_sources(config, query \\ %{}) do
-    Request.get(config, "/heat-sources", query)
-  end
-
   # Household
 
   def create_household(config, attrs, rels) do

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -106,6 +106,14 @@ endpoints = [
     type: "fiscal-years"
   },
   %{
+    endpoints: [:index, :show, :update, :delete],
+    model: WiseHomex.Gateway,
+    name_plural: "gateways",
+    name_singular: "gateway",
+    path: "/gateways",
+    type: "gateways"
+  },
+  %{
     endpoints: [:show, :create],
     model: WiseHomex.StatementData,
     name_plural: "statement_datas",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -114,6 +114,14 @@ endpoints = [
     type: "gateways"
   },
   %{
+    endpoints: [:index, :show],
+    model: WiseHomex.HeatSource,
+    name_plural: "heat_sources",
+    name_singular: "heat_source",
+    path: "/heat-sources",
+    type: "heat-sources"
+  },
+  %{
     endpoints: [:show, :create],
     model: WiseHomex.StatementData,
     name_plural: "statement_datas",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -122,6 +122,14 @@ endpoints = [
     type: "heat-sources"
   },
   %{
+    endpoints: [:index, :show, :create, :update, :delete],
+    model: WiseHomex.Household,
+    name_plural: "households",
+    name_singular: "household",
+    path: "/households",
+    type: "households"
+  },
+  %{
     endpoints: [:show, :create],
     model: WiseHomex.StatementData,
     name_plural: "statement_datas",

--- a/lib/wise_homex/api_config.exs
+++ b/lib/wise_homex/api_config.exs
@@ -130,6 +130,14 @@ endpoints = [
     type: "households"
   },
   %{
+    endpoints: [:index, :show, :create, :update, :delete],
+    model: WiseHomex.Property,
+    name_plural: "properties",
+    name_singular: "property",
+    path: "/properties",
+    type: "properties"
+  },
+  %{
     endpoints: [:show, :create],
     model: WiseHomex.StatementData,
     name_plural: "statement_datas",

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -18,7 +18,6 @@ defmodule WiseHomex.JSONParser do
              "measurements" => WiseHomex.Measurement,
              "message-reports" => WiseHomex.MessageReport,
              "pongs" => WiseHomex.Pong,
-             "properties" => WiseHomex.Property,
              "radiator-import-results" => WiseHomex.RadiatorImportResult,
              "radiator-infos" => WiseHomex.RadiatorInfo,
              "radiators" => WiseHomex.Radiator,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -13,7 +13,6 @@ defmodule WiseHomex.JSONParser do
              "device-imports" => WiseHomex.DeviceImport,
              "device-types" => WiseHomex.DeviceType,
              "encryption-keys" => WiseHomex.EncKey,
-             "gateways" => WiseHomex.Gateway,
              "heat-sources" => WiseHomex.HeatSource,
              "households" => WiseHomex.Household,
              "kems" => WiseHomex.KEMInfo,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -13,7 +13,6 @@ defmodule WiseHomex.JSONParser do
              "device-imports" => WiseHomex.DeviceImport,
              "device-types" => WiseHomex.DeviceType,
              "encryption-keys" => WiseHomex.EncKey,
-             "households" => WiseHomex.Household,
              "kems" => WiseHomex.KEMInfo,
              "latest-reports" => WiseHomex.LatestReport,
              "measurements" => WiseHomex.Measurement,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -13,7 +13,6 @@ defmodule WiseHomex.JSONParser do
              "device-imports" => WiseHomex.DeviceImport,
              "device-types" => WiseHomex.DeviceType,
              "encryption-keys" => WiseHomex.EncKey,
-             "heat-sources" => WiseHomex.HeatSource,
              "households" => WiseHomex.Household,
              "kems" => WiseHomex.KEMInfo,
              "latest-reports" => WiseHomex.LatestReport,

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -68,18 +68,6 @@ defmodule WiseHomex.Test.ApiClientMock do
   end
 
   # Gateway
-  def get_gateway(_config, id, query) do
-    call_and_get_mock_value(:get_gateway, %{id: id, query: query})
-  end
-
-  def get_gateways(_config, query) do
-    call_and_get_mock_value(:get_gateways, %{query: query})
-  end
-
-  def delete_gateway(_config, id) do
-    call_and_get_mock_value(:delete_gateway, %{id: id})
-  end
-
   def lock_gateway(_config, id) do
     call_and_get_mock_value(:lock_gateway, %{id: id})
   end
@@ -90,10 +78,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   def unlock_gateway(_config, id, seconds) do
     call_and_get_mock_value(:unlock_gateway, %{id: id, seconds: seconds})
-  end
-
-  def update_gateway(_config, id, attrs, rels) do
-    call_and_get_mock_value(:update_gateway, %{id: id, attrs: attrs, rels: rels})
   end
 
   # HeatSource

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -10,6 +10,11 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   import WiseHomex.Test.ApiClientMockServer, only: [call_and_get_mock_value: 2]
 
+  # Account invitation
+  def create_account_invitation(_config, account_id, attrs) do
+    call_and_get_mock_value(:create_account_invitation, %{account_id: account_id, attrs: attrs})
+  end
+
   # Angel Note
   def get_angel_note(_config, target_type, target_id) do
     call_and_get_mock_value(:get_angel_note, %{target_type: target_type, target_id: target_id})
@@ -78,11 +83,6 @@ defmodule WiseHomex.Test.ApiClientMock do
 
   def unlock_gateway(_config, id, seconds) do
     call_and_get_mock_value(:unlock_gateway, %{id: id, seconds: seconds})
-  end
-
-  # Account invitation
-  def create_account_invitation(_config, account_id, attrs) do
-    call_and_get_mock_value(:create_account_invitation, %{account_id: account_id, attrs: attrs})
   end
 
   # KEM uploads

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -80,27 +80,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:unlock_gateway, %{id: id, seconds: seconds})
   end
 
-  # Household
-  def create_household(_config, attrs, rels) do
-    call_and_get_mock_value(:create_household, %{attrs: attrs, rels: rels})
-  end
-
-  def delete_household(_config, id) do
-    call_and_get_mock_value(:delete_household, %{id: id})
-  end
-
-  def get_household(_config, id, query) do
-    call_and_get_mock_value(:get_household, %{id: id, query: query})
-  end
-
-  def get_households(_config, query) do
-    call_and_get_mock_value(:get_households, %{query: query})
-  end
-
-  def update_household(_config, id, attrs, rels) do
-    call_and_get_mock_value(:update_household, %{id: id, attrs: attrs, rels: rels})
-  end
-
   # Account invitation
   def create_account_invitation(_config, account_id, attrs) do
     call_and_get_mock_value(:create_account_invitation, %{account_id: account_id, attrs: attrs})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -80,15 +80,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:unlock_gateway, %{id: id, seconds: seconds})
   end
 
-  # HeatSource
-  def get_heat_source(_config, id, query \\ %{}) do
-    call_and_get_mock_value(:get_heat_source, %{id: id, query: query})
-  end
-
-  def get_heat_sources(_config, query \\ %{}) do
-    call_and_get_mock_value(:get_heat_sources, %{query: query})
-  end
-
   # Household
   def create_household(_config, attrs, rels) do
     call_and_get_mock_value(:create_household, %{attrs: attrs, rels: rels})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -95,27 +95,6 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:ping, %{query: query})
   end
 
-  # Property
-  def create_property(_config, attrs, rels) do
-    call_and_get_mock_value(:create_property, %{attrs: attrs, rels: rels})
-  end
-
-  def delete_property(_config, id) do
-    call_and_get_mock_value(:delete_property, %{id: id})
-  end
-
-  def get_properties(_config, query) do
-    call_and_get_mock_value(:get_properties, %{query: query})
-  end
-
-  def get_property(_config, id, query) do
-    call_and_get_mock_value(:get_property, %{id: id, query: query})
-  end
-
-  def update_property(_config, id, attrs, rels) do
-    call_and_get_mock_value(:update_property, %{id: id, attrs: attrs, rels: rels})
-  end
-
   # Property Syncs
   def sync_property(_config, property_id) do
     call_and_get_mock_value(:sync_property, %{property_id: property_id})


### PR DESCRIPTION
Ref: https://github.com/wise-home/wise_homex/issues/125

Migrates the following models to automatic creation:
- Gateway
- HeatSource
- Household
- Property

And fixes the order for AccountInvitation in the custom endpoints