### PR TITLE
Remove radiator string from HeatSource

### DIFF
--- a/lib/wise_homex/models/heat_source.ex
+++ b/lib/wise_homex/models/heat_source.ex
@@ -11,7 +11,6 @@ defmodule WiseHomex.HeatSource do
     field :length, :integer
     field :remote, :boolean
     field :source_type, :string
-    field :radiator_string, :string
     field :active_from, :date
     field :active_to, :date
   end


### PR DESCRIPTION
The `radiator_string` field is no longer present on the `HeatSource` model. It should be removed here too.