### PR TITLE
Change actions/setup-elixir to erlef/setup-elixir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
         name: Cache _build
         with:
           path: _build
-          key: build-${{ env.cache_version }}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
+          key: build-erlef-${{ env.cache_version }}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            build-${{ env.cache_version }}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
+            build-erlef-${{ env.cache_version }}-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
 
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         name: Setup elixir
         with:
           otp-version: ${{matrix.otp}}


### PR DESCRIPTION
A notice has been added to the [setup-elixir repository](https://github.com/actions/setup-elixir):

> Please note: This repository is currently unmaintained by a team of developers at GitHub. It is now maintained by the Erlang Ecosystem Foundation at erlef/setup-elixir. Rather than using actions/setup-elixir, please begin referring to that action in your workflows, instead.

This PR changes to use `erlef/setup-elixir@v1`