### PR TITLE
models/statement_config: Remove :enabled field

### DIFF
--- a/lib/wise_homex/models/statement_config.ex
+++ b/lib/wise_homex/models/statement_config.ex
@@ -16,7 +16,6 @@ defmodule WiseHomex.StatementConfig do
 
     field :company_number_length, :integer
     field :customer_reference, :string
-    field :enabled, :boolean
     field :flatrate, :boolean
     field :hca_ratio, DecimalType
     field :heat_hca_ratio, DecimalType


### PR DESCRIPTION
Remove the :enabled flag from statement config. It is superseded by
the :statements_enabled flag on property.