### PR TITLE
account_payment: Refactor total and vat amount

### DIFF
--- a/lib/wise_homex/models/account_payment.ex
+++ b/lib/wise_homex/models/account_payment.ex
@@ -9,10 +9,9 @@ defmodule WiseHomex.AccountPayment do
     belongs_to :tenancy, WiseHomex.Tenancy, type: :binary_id
     belongs_to :fiscal_year, WiseHomex.FiscalYear, type: :binary_id
     field :accounting_date, :date
-    field :currency, :string
     field :excluded, :boolean
-    field :total_amount, :integer
-    field :vat_amount, :integer
+    field :q_total_amount, WiseHomex.QuantityType
+    field :q_vat_amount, WiseHomex.QuantityType
 
     timestamps type: :utc_datetime
   end


### PR DESCRIPTION
We are refactoring the API for account payments.
In this process we now expose quantity versions of the two fields:
 1. total amount
 2. vat amount

Later we will deprecated the non-q-prefix versions of the fields.