### PR TITLE
Restrict Github Action permissions to read-only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: CI
 
 on: push
 
+# Set the GITHUB_TOKEN to a restricted permission we don't need anything else than this.
+# This will disable all other permissions than metadata: read, which is always enabled.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR restricts the GITHUB_TOKEN permissions to `contents: read` which is the only needed permission.