### PR TITLE
Add calculate missing readings

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -120,6 +120,10 @@ defmodule WiseHomex do
   """
   def upload_bmeters_keys(config, opts), do: api_client().upload_bmeters_keys(config, opts)
 
+  # Calculate missing readings
+  def calculate_missing_readings(config, statement_id),
+    do: api_client().calculate_missing_readings(config, statement_id)
+
   # Device
 
   @doc """

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -69,6 +69,9 @@ defmodule WiseHomex.ApiClientBehaviour do
   # Bmeters Keys
   @callback upload_bmeters_keys(Config.t(), list) :: response
 
+  # Calculate missing readings
+  @callback calculate_missing_readings(Config.t(), id) :: response
+
   # Device
   @callback authorize_device(Config.t(), id) :: response
   @callback create_device(Config.t(), attributes, relationships, query) :: response

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -64,6 +64,22 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/bmeters/keys", payload)
   end
 
+  # Calculate missing readings
+  def calculate_missing_readings(config, statement_id) do
+    payload =
+      %{
+        data: %{
+          type: "calculate-missing-readings",
+          relationships: %{
+            statement: %{data: %{type: "statements", id: statement_id}}
+          }
+        }
+      }
+      |> normalize_payload()
+
+    Request.post(config, "/calculate-missing-readings", payload)
+  end
+
   # Device
   def authorize_device(config, device_id) do
     Request.post(config, "/devices/" <> device_id <> "/authorizations")

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -30,6 +30,11 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:upload_bmeters_keys, %{opts: opts})
   end
 
+  # Calculate missing readings
+  def calculate_missing_readings(_config, statement_id) do
+    call_and_get_mock_value(:calculate_missing_readings, %{statement_id: statement_id})
+  end
+
   # Device
   def authorize_device(_config, device_id) do
     call_and_get_mock_value(:authorize_device, %{device_id: device_id})


### PR DESCRIPTION
Adds the call to `calculate_missing_readings`. It has been tested and works in practice.