### PR TITLE
Add support for READy Matches

### DIFF
--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -245,6 +245,12 @@ defmodule WiseHomex do
   def ready_installation_matches(config, rels, query \\ %{}),
     do: api_client().ready_installation_matches(config, rels, query)
 
+  def link_ready_installation_match(config, rels, query \\ %{}),
+    do: api_client().link_ready_installation_match(config, rels, query)
+
+  def unlink_ready_installation_match(config, rels, query \\ %{}),
+    do: api_client().unlink_ready_installation_match(config, rels, query)
+
   # Statement
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -241,6 +241,10 @@ defmodule WiseHomex do
   """
   def import_radiators(config, attrs), do: api_client().import_radiators(config, attrs)
 
+  # READy
+  def ready_installation_matches(config, rels, query \\ %{}),
+    do: api_client().ready_installation_matches(config, rels, query)
+
   # Statement
 
   @doc """

--- a/lib/wise_homex.ex
+++ b/lib/wise_homex.ex
@@ -245,6 +245,9 @@ defmodule WiseHomex do
   def ready_installation_matches(config, rels, query \\ %{}),
     do: api_client().ready_installation_matches(config, rels, query)
 
+  def ready_installation_already_matched(config, rels, query \\ %{}),
+    do: api_client().ready_installation_already_matched(config, rels, query)
+
   def link_ready_installation_match(config, rels, query \\ %{}),
     do: api_client().link_ready_installation_match(config, rels, query)
 

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -231,6 +231,7 @@ defmodule WiseHomex.ApiClientBehaviour do
 
   # READy Installation Matches
   @callback ready_installation_matches(Config.t(), relationships, query) :: response
+  @callback ready_installation_already_matched(Config.t(), relationships, query) :: response
   @callback link_ready_installation_match(Config.t(), relationships, query) :: response
   @callback unlink_ready_installation_match(Config.t(), relationships, query) :: response
 

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -231,6 +231,8 @@ defmodule WiseHomex.ApiClientBehaviour do
 
   # READy Installation Matches
   @callback ready_installation_matches(Config.t(), relationships, query) :: response
+  @callback link_ready_installation_match(Config.t(), relationships, query) :: response
+  @callback unlink_ready_installation_match(Config.t(), relationships, query) :: response
 
   # Reports
   @callback create_latest_report(Config.t(), id, query) :: response

--- a/lib/wise_homex/api_client_behaviour.ex
+++ b/lib/wise_homex/api_client_behaviour.ex
@@ -229,6 +229,9 @@ defmodule WiseHomex.ApiClientBehaviour do
   # READy Installation
   @callback get_ready_installations(Config.t(), query) :: response
 
+  # READy Installation Matches
+  @callback ready_installation_matches(Config.t(), relationships, query) :: response
+
   # Reports
   @callback create_latest_report(Config.t(), id, query) :: response
   @callback get_device_reports(Config.t(), id) :: response

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -288,6 +288,17 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/ready-installation-matches", payload, query)
   end
 
+  def ready_installation_already_matched(config, rels, query \\ %{}) do
+    payload = %{
+      data: %{
+        type: "ready-installation-already-matched",
+        relationships: rels
+      }
+    }
+
+    Request.post(config, "/ready-installation-already-matched", payload, query)
+  end
+
   def link_ready_installation_match(config, rels, query \\ %{}) do
     payload = %{
       data: %{

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -288,6 +288,28 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/ready-installation-matches", payload, query)
   end
 
+  def link_ready_installation_match(config, rels, query \\ %{}) do
+    payload = %{
+      data: %{
+        type: "ready-installation-links",
+        relationships: rels
+      }
+    }
+
+    Request.post(config, "/ready-installation-links", payload, query)
+  end
+
+  def unlink_ready_installation_match(config, rels, query \\ %{}) do
+    payload = %{
+      data: %{
+        type: "ready-installation-unlinks",
+        relationships: rels
+      }
+    }
+
+    Request.post(config, "/ready-installation-unlinks", payload, query)
+  end
+
   # Reports
   def create_latest_report(config, device_id, query \\ %{}) do
     payload = %{

--- a/lib/wise_homex/api_client_impl/api_client_impl.ex
+++ b/lib/wise_homex/api_client_impl/api_client_impl.ex
@@ -276,6 +276,18 @@ defmodule WiseHomex.ApiClientImpl do
     Request.post(config, "/radiators/import", payload)
   end
 
+  # READy
+  def ready_installation_matches(config, rels, query \\ %{}) do
+    payload = %{
+      data: %{
+        type: "ready-installation-matches",
+        relationships: rels
+      }
+    }
+
+    Request.post(config, "/ready-installation-matches", payload, query)
+  end
+
   # Reports
   def create_latest_report(config, device_id, query \\ %{}) do
     payload = %{

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -20,6 +20,7 @@ defmodule WiseHomex.JSONParser do
              "message-reports" => WiseHomex.MessageReport,
              "pongs" => WiseHomex.Pong,
              "radiator-import-results" => WiseHomex.RadiatorImportResult,
+             "ready-installation-matches" => WiseHomex.ReadyInstallationMatch,
              "vacancies" => WiseHomex.Vacancy,
              "vacancy-infos" => WiseHomex.VacancyInfo,
              "wmbus-device-types" => WiseHomex.WMBusDeviceType,

--- a/lib/wise_homex/json_parser.ex
+++ b/lib/wise_homex/json_parser.ex
@@ -21,6 +21,7 @@ defmodule WiseHomex.JSONParser do
              "pongs" => WiseHomex.Pong,
              "radiator-import-results" => WiseHomex.RadiatorImportResult,
              "ready-installation-matches" => WiseHomex.ReadyInstallationMatch,
+             "ready-installation-already-matched" => WiseHomex.ReadyInstallationMatch,
              "vacancies" => WiseHomex.Vacancy,
              "vacancy-infos" => WiseHomex.VacancyInfo,
              "wmbus-device-types" => WiseHomex.WMBusDeviceType,

--- a/lib/wise_homex/models/ready_installation_match.ex
+++ b/lib/wise_homex/models/ready_installation_match.ex
@@ -1,0 +1,15 @@
+defmodule WiseHomex.ReadyInstallationMatch do
+  @moduledoc false
+
+  use WiseHomex.BaseModel
+
+  alias WiseHomex.Household
+  alias WiseHomex.ReadyInstallation
+
+  embedded_schema do
+    belongs_to :household, Household
+    belongs_to :ready_installation, ReadyInstallation, type: :binary_id
+
+    field :distance, :integer
+  end
+end

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -117,6 +117,10 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:ready_installation_matches, %{relationships: relationships, query: query})
   end
 
+  def ready_installation_already_matched(_config, relationships, query) do
+    call_and_get_mock_value(:ready_installation_already_matched, %{relationships: relationships, query: query})
+  end
+
   def link_ready_installation_match(_config, relationships, query) do
     call_and_get_mock_value(:link_ready_installation_match, %{relationships: relationships, query: query})
   end

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -112,6 +112,11 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:import_radiators, %{attrs: attrs})
   end
 
+  # READy
+  def ready_installation_matches(_config, relationships, query) do
+    call_and_get_mock_value(:ready_installation_matches, %{relationships: relationships, query: query})
+  end
+
   # Reports
   def get_device_reports(_config, id) do
     call_and_get_mock_value(:get_device_reports, %{id: id})

--- a/lib/wise_homex/test/api_client_mock/api_client_mock.ex
+++ b/lib/wise_homex/test/api_client_mock/api_client_mock.ex
@@ -117,6 +117,14 @@ defmodule WiseHomex.Test.ApiClientMock do
     call_and_get_mock_value(:ready_installation_matches, %{relationships: relationships, query: query})
   end
 
+  def link_ready_installation_match(_config, relationships, query) do
+    call_and_get_mock_value(:link_ready_installation_match, %{relationships: relationships, query: query})
+  end
+
+  def unlink_ready_installation_match(_config, relationships, query) do
+    call_and_get_mock_value(:unlink_ready_installation_match, %{relationships: relationships, query: query})
+  end
+
   # Reports
   def get_device_reports(_config, id) do
     call_and_get_mock_value(:get_device_reports, %{id: id})


### PR DESCRIPTION
We need to link/sync READy installations with WiseHome households. Support the necessary model and endpoints to query possible matches and to link/unlink matches.