### PR TITLE
Improve feedback when no more mocks

### DIFF
--- a/test/api_client_mock_server_test.exs
+++ b/test/api_client_mock_server_test.exs
@@ -85,6 +85,24 @@ defmodule ApiClientMockServerTest do
              {:error, "No mock set for call", :non_existing, %{hej: true}}
   end
 
+  test "it returns no more mocks exists if called was mocked but used up" do
+    opts = %{params: [1, 2, 3, 4], query: %{"hej" => "med_dig"}}
+
+    MockServer.set(
+      :some_function,
+      opts,
+      {:ok, 1234},
+      3
+    )
+
+    MockServer.call_and_get_mock_value(:some_function, opts)
+    MockServer.call_and_get_mock_value(:some_function, opts)
+    MockServer.call_and_get_mock_value(:some_function, opts)
+
+    assert MockServer.call_and_get_mock_value(:some_function, opts) ==
+             {:error, "No more mocks set for call", :some_function, opts}
+  end
+
   test "it leaves state untouched when getting a value for a non existing mock" do
     MockServer.set(
       :other_function,


### PR DESCRIPTION
It can be confusing for the user of the mock server when
a call is mocked but it is needed (called) more than expected.

This commit introduces another error message:

  {:error, "No more mocks set for call", api_function, opts}

in addition to the already existing error

  {:error, "No mock set for call", api_function, opts}
  
Closes: #334 