### PR TITLE
ready_meter: Rename two sync fields

### DIFF
--- a/lib/wise_homex/models/ready_meter.ex
+++ b/lib/wise_homex/models/ready_meter.ex
@@ -13,7 +13,7 @@ defmodule WiseHomex.ReadyMeter do
     field :meter_type, :string
     field :serial_number, :string
 
-    field :last_ready_sync_attempt_at, :utc_datetime
-    field :last_ready_measurement_from, :utc_datetime
+    field :last_sync_attempt_at, :utc_datetime
+    field :last_measurement_from, :utc_datetime
   end
 end


### PR DESCRIPTION
Two fields have been renamed in the API. This PR renames the same two fields in WiseHomex.