### PR TITLE
api_client_mock_server: Add support for failed calls

### DIFF
--- a/test/api_client_mock_server_test.exs
+++ b/test/api_client_mock_server_test.exs
@@ -142,4 +142,21 @@ defmodule ApiClientMockServerTest do
 
     assert MockServer.remaining_calls() == %{}
   end
+
+  test "return all failed calls" do
+    MockServer.set(:some_function, %{}, {:ok, 1234})
+
+    assert MockServer.call_and_get_mock_value(:non_existing, %{a: :b}) ==
+             {:error, "No mock set for call", :non_existing, %{a: :b}}
+
+    assert {:ok, 1234} = MockServer.call_and_get_mock_value(:some_function, %{})
+
+    assert MockServer.call_and_get_mock_value(:non_existing_dos, %{c: :d}) ==
+             {:error, "No mock set for call", :non_existing_dos, %{c: :d}}
+
+    assert MockServer.failed_calls() == [
+             {:non_existing, %{a: :b}},
+             {:non_existing_dos, %{c: :d}}
+           ]
+  end
 end


### PR DESCRIPTION
It is sometimes really good to see exactly which calls to the mock
failed and in which order.

To implement this feature I cleaned up and simplified some code when
popping values in the mock.