### PR TITLE
feat(distributed-expense): add partial field and nil for expense type

### DIFF
--- a/lib/wise_homex/models/distributed_expense.ex
+++ b/lib/wise_homex/models/distributed_expense.ex
@@ -12,6 +12,7 @@ defmodule WiseHomex.DistributedExpense do
     field :business_only, :boolean
     field :expense_type, :string
     field :title, :string
+    field :partial, :boolean
   end
 
   @doc """
@@ -19,6 +20,7 @@ defmodule WiseHomex.DistributedExpense do
   """
   def supported_types() do
     [
+      nil,
       "energy_label",
       "distribution_statement",
       "caretaker",


### PR DESCRIPTION
### Description
- Added a new boolean field `partial` to DistributedExpense model
- Updated supported_types function to include nil type

### Related Tickets & Documents
- https://github.com/wise-home/legolas/pull/5198