### PR TITLE
feat(broken-account-payment): add unassoc_tenancy_external_id field

### DIFF
--- a/lib/wise_homex/models/broken_account_payment.ex
+++ b/lib/wise_homex/models/broken_account_payment.ex
@@ -12,6 +12,7 @@ defmodule WiseHomex.BrokenAccountPayment do
     field :period_from, :date
     field :period_to, :date
     field :utility_type, :string
+    field :unassoc_tenancy_external_id, :string
     field :external_system, :string
     field :external_id, :string
   end


### PR DESCRIPTION
- add a new field `unassoc_tenancy_external_id` to track tenant IDs not associated with any account

Related to wise-home/legolas#5124